### PR TITLE
Add support for services in rmw_connext

### DIFF
--- a/rmw_connext_cpp/include/rmw_connext_cpp/impl/rmw/get_service_type_support_handle.h
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/impl/rmw/get_service_type_support_handle.h
@@ -1,4 +1,3 @@
-
 #ifndef __rmw__get_service_type_support_handle__h__
 #define __rmw__get_service_type_support_handle__h__
 
@@ -7,7 +6,7 @@
 namespace rmw
 {
 template<typename T>
-const rosidl_generator_cpp::ServiceTypeSupportHandle& get_service_type_support_handle()
+const rosidl_service_type_support_t * get_service_type_support_handle()
 {
   return rmw_connext_cpp::get_service_type_support_handle<T>();
 }

--- a/rmw_connext_cpp/include/rmw_connext_cpp/impl/rmw/get_type_support_handle.h
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/impl/rmw/get_type_support_handle.h
@@ -7,7 +7,7 @@
 namespace rmw
 {
 template<typename T>
-const rosidl_generator_cpp::MessageTypeSupportHandle& get_type_support_handle()
+const rosidl_service_type_support_t * get_type_support_handle()
 {
   return rmw_connext_cpp::get_type_support_handle<T>();
 }

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -287,6 +287,11 @@ rmw_create_subscription(const rmw_node_t * node,
 rmw_ret_t
 rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * taken)
 {
+    if (taken == NULL) {
+        rmw_set_error_string("taken argument can't be null");
+        return RMW_RET_ERROR;
+    }
+
     if (subscription->implementation_identifier != _rti_connext_identifier)
     {
         rmw_set_error_string("subscriber handle not from this implementation");
@@ -626,6 +631,11 @@ rmw_ret_t
 rmw_take_request(const rmw_service_t * service,
                  void * ros_request_header, void * ros_request, bool * taken)
 {
+    if (taken == NULL) {
+        rmw_set_error_string("taken argument can't be null");
+        return RMW_RET_ERROR;
+    }
+
     if (service->implementation_identifier != _rti_connext_identifier)
     {
         rmw_set_error_string("service handle not from this implementation");
@@ -648,6 +658,11 @@ rmw_ret_t
 rmw_take_response(const rmw_client_t * client,
                   void * ros_request_header, void * ros_response, bool * taken)
 {
+    if (taken == NULL) {
+        rmw_set_error_string("taken argument can't be null");
+        return RMW_RET_ERROR;
+    }
+
     if (client->implementation_identifier != _rti_connext_identifier)
     {
         rmw_set_error_string("client handle not from this implementation");

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -1,5 +1,3 @@
-#include <rmw/types.h>
-
 #include <iostream>
 #include <stdexcept>
 
@@ -9,6 +7,8 @@
 #include <rmw/rmw.h>
 #include <rmw/allocators.h>
 #include <rmw/error_handling.h>
+#include <rmw/types.h>
+
 #include "rosidl_generator_cpp/MessageTypeSupport.h"
 #include "rosidl_typesupport_connext_cpp/MessageTypeSupport.h"
 

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -639,7 +639,7 @@ rmw_take_request(const rmw_service_t * service,
 
     const rmw_connext_cpp::ServiceTypeSupportCallbacks * callbacks = custom_service_info->callbacks_;
 
-    *taken = callbacks->_take_request(replier, ros_request, ros_request_header);
+    *taken = callbacks->_take_request(replier, ros_request_header, ros_request);
 
     return RMW_RET_OK;
 }
@@ -661,14 +661,14 @@ rmw_take_response(const rmw_client_t * client,
 
     const rmw_connext_cpp::ServiceTypeSupportCallbacks * callbacks = custom_client_info->callbacks_;
 
-    *taken = callbacks->_take_response(requester, ros_response, ros_request_header);
+    *taken = callbacks->_take_response(requester, ros_request_header, ros_response);
 
     return RMW_RET_OK;
 }
 
 rmw_ret_t
 rmw_send_response(const rmw_service_t * service,
-                  void * ros_request, void * ros_response)
+                  void * ros_request_header, void * ros_response)
 {
     if (service->implementation_identifier != _rti_connext_identifier)
     {
@@ -683,7 +683,7 @@ rmw_send_response(const rmw_service_t * service,
 
     const rmw_connext_cpp::ServiceTypeSupportCallbacks * callbacks = custom_service_info->callbacks_;
 
-    callbacks->_send_response(replier, ros_request, ros_response);
+    callbacks->_send_response(replier, ros_request_header, ros_response);
     return RMW_RET_OK;
 }
 

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -31,18 +31,21 @@ struct CustomClientInfo {
   rmw_connext_cpp::ServiceTypeSupportCallbacks * callbacks_;
 };
 
-void init()
+rmw_ret_t
+rmw_init()
 {
     std::cout << "init()" << std::endl;
     std::cout << "  init() get_instance" << std::endl;
     DDSDomainParticipantFactory* dpf_ = DDSDomainParticipantFactory::get_instance();
     if (!dpf_) {
         printf("  init() could not get participant factory\n");
-        throw std::runtime_error("could not get participant factory");
+        return RMW_RET_ERROR;
     };
+    return RMW_RET_OK;
 }
 
-rmw_node_t * create_node(const char * name)
+rmw_node_t *
+rmw_create_node(const char * name)
 {
     std::cout << "create_node()" << std::endl;
 
@@ -195,7 +198,8 @@ rmw_publisher_t * create_publisher(
     return publisher;
 }
 
-void publish(const rmw_publisher_t * publisher, const void * ros_message)
+rmw_ret_t
+rmw_publish(const rmw_publisher_t * publisher, const void * ros_message)
 {
     //std::cout << "publish()" << std::endl;
 
@@ -203,7 +207,7 @@ void publish(const rmw_publisher_t * publisher, const void * ros_message)
     {
         printf("publisher handle not from this implementation\n");
         printf("but from: %s\n", publisher->implementation_identifier);
-        throw std::runtime_error("publisher handle not from this implementation");
+        return RMW_RET_ERROR;
     }
 
     //std::cout << "  publish() extract data writer and type code from opaque publisher handle" << std::endl;
@@ -214,6 +218,7 @@ void publish(const rmw_publisher_t * publisher, const void * ros_message)
 
     //std::cout << "  publish() invoke publish callback" << std::endl;
     callbacks->_publish(topic_writer, ros_message);
+    return RMW_RET_OK;
 }
 
 struct CustomSubscriberInfo {
@@ -300,7 +305,8 @@ rmw_subscription_t * create_subscription(
     return subscription;
 }
 
-rmw_ret_t take(const rmw_subscription_t * subscription, void * ros_message)
+rmw_ret_t
+take(const rmw_subscription_t * subscription, void * ros_message)
 {
     if (subscription->implementation_identifier != _rti_connext_identifier)
     {
@@ -325,7 +331,8 @@ rmw_guard_condition_t * create_guard_condition()
 
 }
 
-void trigger_guard_condition(const rmw_guard_condition_t * guard_condition_handle)
+rmw_ret_t
+rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition_handle)
 {
     //std::cout << "trigger_guard_condition()" << std::endl;
 
@@ -340,7 +347,7 @@ void trigger_guard_condition(const rmw_guard_condition_t * guard_condition_handl
     guard_condition->set_trigger_value(DDS_BOOLEAN_TRUE);
 }
 
-void
+rmw_ret_t
 rmw_wait(rmw_subscriptions_t * subscriptions,
          rmw_guard_conditions_t * guard_conditions,
          rmw_services_t * services,
@@ -514,7 +521,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
             clients->clients[i] = 0;
         }
     }
-
+    return RMW_RET_OK;
 }
 
 rmw_client_t * create_client(

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/MessageTypeSupport.h
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/MessageTypeSupport.h
@@ -2,6 +2,7 @@
 #ifndef __rmw_connext_cpp__MessageTypeSupport__h__
 #define __rmw_connext_cpp__MessageTypeSupport__h__
 
+#include <rosidl_generator_c/message_type_support.h>
 #include "rosidl_generator_cpp/MessageTypeSupport.h"
 
 class DDSDomainParticipant;
@@ -28,7 +29,7 @@ typedef struct MessageTypeSupportCallbacks {
 } MessageTypeSupportCallbacks;
 
 template<typename T>
-const rosidl_generator_cpp::MessageTypeSupportHandle& get_type_support_handle();
+const rosidl_message_type_support_t * get_type_support_handle();
 
 }  // namespace rmw_connext_cpp
 

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/ServiceTypeSupport.h
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/ServiceTypeSupport.h
@@ -1,8 +1,8 @@
-
 #ifndef __rmw_connext_cpp__ServiceTypeSupport__h__
 #define __rmw_connext_cpp__ServiceTypeSupport__h__
 
 #include <rmw/rmw.h>
+#include <rosidl_generator_c/service_type_support.h>
 #include "rosidl_generator_cpp/ServiceTypeSupport.h"
 
 class DDSDomainParticipant;
@@ -25,14 +25,13 @@ typedef struct ServiceTypeSupportCallbacks {
   void* (*_create_requester)(DDSDomainParticipant * participant, const char * service_name, DDSDataReader **reader);
   void* (*_create_replier)(DDSDomainParticipant * participant, const char * service_name, DDSDataReader **reader);
   int64_t (*_send_request)(void * requester, const void * ros_request);
-  ::rmw::ROS2_RETCODE_t (*_receive_response)(void * requester, void * ros_response);
   bool (*_take_request)(void * replier, void * ros_request, void * ros_request_header);
   void (*_send_response)(void * replier, const void * ros_request, const void * ros_response);
   bool (*_take_response)(void * requester, void * ros_response, void * ros_request_header);
 } ServiceTypeSupportCallbacks;
 
 template<typename T>
-const rosidl_generator_cpp::ServiceTypeSupportHandle& get_service_type_support_handle();
+const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rmw_connext_cpp
 

--- a/rosidl_typesupport_connext_cpp/resource/msg_TypeSupport.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg_TypeSupport.cpp.template
@@ -211,7 +211,7 @@ static rmw_connext_cpp::MessageTypeSupportCallbacks callbacks = {
     &take__@(spec.base_type.type)
 };
 
-static rosidl_generator_cpp::MessageTypeSupportHandle handle = {
+static rosidl_message_type_support_t handle = {
     "connext_static",
     &callbacks
 };
@@ -220,14 +220,26 @@ static rosidl_generator_cpp::MessageTypeSupportHandle handle = {
 
 }  // namespace @(spec.base_type.pkg_name)
 
-
 namespace rmw_connext_cpp
 {
 
 template<>
-const rosidl_generator_cpp::MessageTypeSupportHandle& get_type_support_handle<@(spec.base_type.pkg_name)::@(spec.base_type.type)>()
+const rosidl_message_type_support_t * get_type_support_handle<@(spec.base_type.pkg_name)::@(spec.base_type.type)>()
 {
-    return @(spec.base_type.pkg_name)::type_support::handle;
+    return &@(spec.base_type.pkg_name)::type_support::handle;
 }
 
 }  // namespace rmw_connext_cpp
+
+namespace rosidl_generator_cpp
+{
+
+template<>
+const rosidl_message_type_support_t *
+get_type_support_handle<@(spec.base_type.pkg_name)::@(spec.base_type.type)>()
+{
+    return rmw_connext_cpp::get_type_support_handle<
+        @(spec.base_type.pkg_name)::@(spec.base_type.type)>();
+}
+
+}  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
@@ -71,25 +71,6 @@ void * create_replier__@(spec.srv_name)(DDSDomainParticipant * participant, cons
     return replier;
 }
 
-ros_middleware_interface::ROS2_RETCODE_t receive_response__@(spec.srv_name)(void * untyped_requester, void * untyped_ros_response)
-{
-    @(spec.pkg_name)::@(spec.srv_name)Response & ros_response = *(@(spec.pkg_name)::@(spec.srv_name)Response *)untyped_ros_response;
-    connext::Requester<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> * requester = reinterpret_cast<connext::Requester<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> *>(untyped_requester);
-
-    // TODO(esteve): add a sane default timeout.
-    const DDS::Duration_t MAX_WAIT = {1, 0};
-    connext::Sample<@(spec.pkg_name)::dds_::@(spec.srv_name)Response_> response;
-    bool received = requester->receive_reply(response, MAX_WAIT);
-    if(received)
-    {
-        if(response.info().valid_data) {
-            @(spec.pkg_name)::type_support::convert_dds_message_to_ros(response.data(), ros_response);
-            return ros_middleware_interface::ROS2_RETCODE_OK;
-        }
-    }
-    return ros_middleware_interface::ROS2_RETCODE_ERROR;
-}
-
 bool take_request__@(spec.srv_name)(void * untyped_replier, void * untyped_ros_request, void * untyped_ros_request_header)
 {
     @(spec.pkg_name)::@(spec.srv_name)Request & ros_request = *(@(spec.pkg_name)::@(spec.srv_name)Request *)untyped_ros_request;
@@ -169,13 +150,12 @@ static rmw_connext_cpp::ServiceTypeSupportCallbacks callbacks = {
     &create_requester__@(spec.srv_name),
     &create_replier__@(spec.srv_name),
     &send_request__@(spec.srv_name),
-    &receive_response__@(spec.srv_name),
     &take_request__@(spec.srv_name),
     &send_response__@(spec.srv_name),
     &take_response__@(spec.srv_name),
 };
 
-static rosidl_generator_cpp::ServiceTypeSupportHandle handle = {
+static rosidl_generator_cpp::rosidl_service_type_support_t handle = {
     "connext_static",
     &callbacks
 };
@@ -189,9 +169,9 @@ namespace rmw_connext_cpp
 {
 
 template<>
-const rosidl_generator_cpp::ServiceTypeSupportHandle& get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
+const rosidl_generator_cpp::rosidl_service_type_support_t * get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
 {
-    return @(spec.pkg_name)::service_type_support::handle;
+    return &@(spec.pkg_name)::service_type_support::handle;
 }
 
 }  // namespace rmw_connext_cpp

--- a/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
@@ -74,7 +74,7 @@ void * create_replier__@(spec.srv_name)(DDSDomainParticipant * participant, cons
 bool take_request__@(spec.srv_name)(void * untyped_replier, void * untyped_ros_request, void * untyped_ros_request_header)
 {
     @(spec.pkg_name)::@(spec.srv_name)Request & ros_request = *(@(spec.pkg_name)::@(spec.srv_name)Request *)untyped_ros_request;
-    ros_middleware_interface::RequestId & req_id = *(ros_middleware_interface::RequestId *)untyped_ros_request_header;
+    rmw_request_id_t & req_id = *(rmw_request_id_t *)untyped_ros_request_header;
 
     connext::Replier<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> * replier = reinterpret_cast<connext::Replier<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> *>(untyped_replier);
 
@@ -107,7 +107,7 @@ bool take_response__@(spec.srv_name)(void * untyped_requester, void * untyped_ro
     if(received)
     {
         if(response.info().valid_data) {
-            ros_middleware_interface::RequestId & req_id = *(reinterpret_cast<ros_middleware_interface::RequestId *>(untyped_ros_request_header));
+            rmw_request_id_t & req_id = *(reinterpret_cast<rmw_request_id_t *>(untyped_ros_request_header));
 
             int64_t sequence_number = ((int64_t)response.related_identity().sequence_number.high) << 32 | response.related_identity().sequence_number.low;
             req_id.sequence_number = sequence_number;
@@ -127,7 +127,7 @@ void send_response__@(spec.srv_name)(
     const @(spec.pkg_name)::@(spec.srv_name)Response & ros_response = *(reinterpret_cast<const @(spec.pkg_name)::@(spec.srv_name)Response *>(untyped_ros_response));
     @(spec.pkg_name)::type_support::convert_ros_message_to_dds(ros_response, response.data());
 
-    const ros_middleware_interface::RequestId & req_id = *(reinterpret_cast<const ros_middleware_interface::RequestId *>(untyped_ros_request_header));
+    const rmw_request_id_t & req_id = *(reinterpret_cast<const rmw_request_id_t *>(untyped_ros_request_header));
 
     DDS_SampleIdentity_t request_identity;
 
@@ -155,7 +155,7 @@ static rmw_connext_cpp::ServiceTypeSupportCallbacks callbacks = {
     &take_response__@(spec.srv_name),
 };
 
-static rosidl_generator_cpp::rosidl_service_type_support_t handle = {
+static rosidl_service_type_support_t handle = {
     "connext_static",
     &callbacks
 };
@@ -164,14 +164,27 @@ static rosidl_generator_cpp::rosidl_service_type_support_t handle = {
 
 }  // namespace @(spec.pkg_name)
 
-
 namespace rmw_connext_cpp
 {
 
 template<>
-const rosidl_generator_cpp::rosidl_service_type_support_t * get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
+const rosidl_service_type_support_t *
+get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
 {
     return &@(spec.pkg_name)::service_type_support::handle;
+}
+
+}  // namespace rmw_connext_cpp
+
+namespace rosidl_generator_cpp
+{
+
+template<>
+const rosidl_service_type_support_t *
+get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
+{
+    return rmw_connext_cpp::get_service_type_support_handle<
+        @(spec.pkg_name)::@(spec.srv_name)>();
 }
 
 }  // namespace rmw_connext_cpp

--- a/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv_ServiceTypeSupport.cpp.template
@@ -71,7 +71,7 @@ void * create_replier__@(spec.srv_name)(DDSDomainParticipant * participant, cons
     return replier;
 }
 
-bool take_request__@(spec.srv_name)(void * untyped_replier, void * untyped_ros_request, void * untyped_ros_request_header)
+bool take_request__@(spec.srv_name)(void * untyped_replier, void * untyped_ros_request_header, void * untyped_ros_request)
 {
     @(spec.pkg_name)::@(spec.srv_name)Request & ros_request = *(@(spec.pkg_name)::@(spec.srv_name)Request *)untyped_ros_request;
     rmw_request_id_t & req_id = *(rmw_request_id_t *)untyped_ros_request_header;
@@ -97,7 +97,7 @@ bool take_request__@(spec.srv_name)(void * untyped_replier, void * untyped_ros_r
     return false;
 }
 
-bool take_response__@(spec.srv_name)(void * untyped_requester, void * untyped_ros_response, void * untyped_ros_request_header)
+bool take_response__@(spec.srv_name)(void * untyped_requester, void * untyped_ros_request_header, void * untyped_ros_response)
 {
     @(spec.pkg_name)::@(spec.srv_name)Response & ros_response = *(@(spec.pkg_name)::@(spec.srv_name)Response *)untyped_ros_response;
     connext::Requester<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> * requester = reinterpret_cast<connext::Requester<@(spec.pkg_name)::dds_::@(spec.srv_name)Request_, @(spec.pkg_name)::dds_::@(spec.srv_name)Response_> *>(untyped_requester);


### PR DESCRIPTION
This PR adds support for service in `rmw_connext`. The big changes are:

- Use the C API and structures
- Updates to `rmw_take*` functions caused by ros2/rmw#4

Connects to ros2/rmw_connext#3