### PR TITLE
[xtypes] publisher / subscriber segfaults

### DIFF
--- a/rmw_connext_xtypes_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_xtypes_dynamic_cpp/src/functions.cpp
@@ -202,7 +202,8 @@ rmw_create_publisher(const rmw_node_t * node,
 
     DDSDomainParticipant* participant = (DDSDomainParticipant*)node->data;
 
-    if (type_support->typesupport_identifier != rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier)
+    // TODO avoid string comparison
+    if (strncmp(type_support->typesupport_identifier, rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier, strlen(rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier)))
     {
         rmw_set_error_string("type support not from this implementation");
         // printf("but from: %s\n", type_support->typesupport_identifier);
@@ -442,7 +443,8 @@ rmw_create_subscription(const rmw_node_t * node,
 
     DDSDomainParticipant* participant = (DDSDomainParticipant*)node->data;
 
-    if (type_support->typesupport_identifier != rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier)
+    // TODO avoid string comparison
+    if (strncmp(type_support->typesupport_identifier, rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier, strlen(rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier)))
     {
         rmw_set_error_string("type support not from this implementation");
         // printf("but from: %s\n", type_support->typesupport_identifier);


### PR DESCRIPTION
Example to reproduce: userland unit test `test_(publisher|subscriber)__rmw_connext_xtypes_dynamic_cpp`