### PR TITLE
fix finding Connext

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -70,6 +70,7 @@ set(_expected_library_base_names
   "rticonnextmsgcpp"
 )
 
+set(_expected_library_names "")
 foreach(_base_name IN LISTS _expected_library_base_names)
   if(WIN32)
     list(APPEND _expected_library_names "${_base_name}.lib")
@@ -92,7 +93,6 @@ if(NOT "${_NDDSHOME} " STREQUAL " ")
 
   set(_search_library_paths "")
   foreach(_library_name ${_expected_library_names})
-    list(APPEND _search_library_paths "${_lib_path}/*/${_library_name}")
     list(APPEND _search_library_paths "${_lib_path}/${_library_name}")
   endforeach()
 


### PR DESCRIPTION
This fixes finding Connext for me. Without the patch it find every library twice (one with two consecutive slashes). I am using the binary package of Connext - not the Debian package.

@esteve Please check if this still works for you with the Debian package.