### PR TITLE
Refactoring of create_* and destroy_* functions

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <exception>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
@@ -29,9 +32,21 @@
 #include <rmw/error_handling.h>
 #include <rmw/types.h>
 
+#include <rmw/impl/cpp/macros.hpp>
+
 #include "rosidl_typesupport_connext_cpp/identifier.hpp"
 #include <rosidl_typesupport_connext_cpp/message_type_support.h>
 #include <rosidl_typesupport_connext_cpp/service_type_support.h>
+
+inline std::string
+_create_type_name(
+  const message_type_support_callbacks_t * callbacks,
+  const std::string & sep)
+{
+  return
+    std::string(callbacks->package_name) +
+    "::" + sep + "::dds_::" + callbacks->message_name + "_";
+}
 
 extern "C"
 {
@@ -40,12 +55,14 @@ const char * rti_connext_identifier = "connext_static";
 
 struct ConnextStaticPublisherInfo
 {
+  DDSPublisher * dds_publisher_;
   DDSDataWriter * topic_writer_;
   const message_type_support_callbacks_t * callbacks_;
 };
 
 struct ConnextStaticSubscriberInfo
 {
+  DDSSubscriber * dds_subscriber_;
   DDSDataReader * topic_reader_;
   bool ignore_local_publications;
   const message_type_support_callbacks_t * callbacks_;
@@ -120,7 +137,6 @@ rmw_create_node(const char * name)
   DDS_DomainId_t domain = 0;
 
   DDSDomainParticipant * participant = dpf_->create_participant(
-    //domain, DDS_PARTICIPANT_QOS_DEFAULT, NULL,
     domain, participant_qos, NULL,
     DDS_STATUS_MASK_NONE);
   if (!participant) {
@@ -128,11 +144,58 @@ rmw_create_node(const char * name)
     return NULL;
   }
 
-  rmw_node_t * node_handle = new rmw_node_t;
+  rmw_node_t * node_handle = rmw_node_allocate();
+  if (!node_handle) {
+    rmw_set_error_string("failed to allocate memory for node handle");
+    if (dpf_->delete_participant(participant) != DDS_RETCODE_OK) {
+      std::stringstream ss;
+      ss << "leaking participant while handling failue at " <<
+        __FILE__ << ":" << __LINE__;
+      (std::cerr << ss.str()).flush();
+    }
+    return NULL;
+  }
   node_handle->implementation_identifier = rti_connext_identifier;
   node_handle->data = participant;
 
   return node_handle;
+}
+
+rmw_ret_t
+rmw_destroy_node(rmw_node_t * node)
+{
+  if (!node) {
+    rmw_set_error_string("node handle is null");
+    return RMW_RET_ERROR;
+  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  DDSDomainParticipantFactory * dpf_ = DDSDomainParticipantFactory::get_instance();
+  if (!dpf_) {
+    rmw_set_error_string("failed to get participant factory");
+    return RMW_RET_ERROR;
+  }
+
+  DDSDomainParticipant * participant = static_cast<DDSDomainParticipant *>(node->data);
+  if (!participant) {
+    rmw_set_error_string("participant handle is null");
+  }
+  // This unregisters types and destroys topics which were shared between
+  // publishers and subscribers and could not be cleaned up in the delete functions.
+  participant->delete_contained_entities();
+
+  DDS_ReturnCode_t ret = dpf_->delete_participant(participant);
+  if (ret != DDS_RETCODE_OK) {
+    rmw_set_error_string("failed to delete participant");
+    return RMW_RET_ERROR;
+  }
+
+  rmw_node_free(node);
+
+  return RMW_RET_OK;
 }
 
 rmw_publisher_t *
@@ -146,20 +209,20 @@ rmw_create_publisher(
     rmw_set_error_string("node handle is null");
     return NULL;
   }
-  if (node->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("node handle is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return NULL)
+
   if (!type_support) {
     rmw_set_error_string("type support handle is null");
     return NULL;
   }
-  if (type_support->typesupport_identifier !=
-    rosidl_typesupport_connext_cpp::typesupport_connext_identifier)
-  {
-    rmw_set_error_string("type support is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    type support handle,
+    type_support->typesupport_identifier,
+    rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+    return NULL)
 
   DDSDomainParticipant * participant = static_cast<DDSDomainParticipant *>(node->data);
   if (!participant) {
@@ -173,62 +236,73 @@ rmw_create_publisher(
     rmw_set_error_string("callbacks handle is null");
     return NULL;
   }
-  std::string type_name = std::string(callbacks->package_name) + "::msg::dds_::" +
-    callbacks->message_name + "_";
+  std::string type_name = _create_type_name(callbacks, "msg");
+  // Past this point, a failure results in unrolling code in the goto fail block.
+  rmw_publisher_t * publisher = nullptr;
+  bool registered;
+  DDS_PublisherQos publisher_qos;
+  DDS_ReturnCode_t status;
+  DDSPublisher * dds_publisher = nullptr;
+  DDSTopic * topic;
+  DDSTopicDescription * topic_description = nullptr;
+  DDS_DataWriterQos datawriter_qos;
+  DDSDataWriter * topic_writer = nullptr;
+  void * buf = nullptr;
+  ConnextStaticPublisherInfo * publisher_info = nullptr;
+  // Begin initializing elements
+  publisher = rmw_publisher_allocate();
+  if (!publisher) {
+    rmw_set_error_string("failed to allocate publisher");
+    goto fail;
+  }
 
-  bool registered = callbacks->register_type(participant, type_name.c_str());
+  registered = callbacks->register_type(participant, type_name.c_str());
   if (!registered) {
     rmw_set_error_string("failed to register type");
-    return NULL;
+    goto fail;
   }
 
-
-  DDS_PublisherQos publisher_qos;
-  DDS_ReturnCode_t status = participant->get_default_publisher_qos(publisher_qos);
+  status = participant->get_default_publisher_qos(publisher_qos);
   if (status != DDS_RETCODE_OK) {
     rmw_set_error_string("failed to get default publisher qos");
-    return NULL;
+    goto fail;
   }
 
-  DDSPublisher * dds_publisher = participant->create_publisher(
+  dds_publisher = participant->create_publisher(
     publisher_qos, NULL, DDS_STATUS_MASK_NONE);
   if (!dds_publisher) {
     rmw_set_error_string("failed to create publisher");
-    return NULL;
+    goto fail;
   }
 
-
-  DDSTopic * topic;
-  DDSTopicDescription * topic_description = participant->lookup_topicdescription(topic_name);
+  topic_description = participant->lookup_topicdescription(topic_name);
   if (!topic_description) {
     DDS_TopicQos default_topic_qos;
     status = participant->get_default_topic_qos(default_topic_qos);
     if (status != DDS_RETCODE_OK) {
       rmw_set_error_string("failed to get default topic qos");
-      return NULL;
+      goto fail;
     }
 
     topic = participant->create_topic(
       topic_name, type_name.c_str(), default_topic_qos, NULL, DDS_STATUS_MASK_NONE);
     if (!topic) {
       rmw_set_error_string("failed to create topic");
-      return NULL;
+      goto fail;
     }
   } else {
     DDS_Duration_t timeout = DDS_Duration_t::from_seconds(0);
     topic = participant->find_topic(topic_name, timeout);
     if (!topic) {
       rmw_set_error_string("failed to find topic");
-      return NULL;
+      goto fail;
     }
   }
 
-
-  DDS_DataWriterQos datawriter_qos;
   status = participant->get_default_datawriter_qos(datawriter_qos);
   if (status != DDS_RETCODE_OK) {
     rmw_set_error_string("failed to get default datawriter qos");
-    return NULL;
+    goto fail;
   }
 
   // ensure the history depth is at least the requested queue size
@@ -248,25 +322,118 @@ rmw_create_publisher(
     DDS_BOOLEAN_FALSE);
   if (status != DDS_RETCODE_OK) {
     rmw_set_error_string("failed to add qos property");
-    return NULL;
+    goto fail;
   }
 
-  DDSDataWriter * topic_writer = dds_publisher->create_datawriter(
+  topic_writer = dds_publisher->create_datawriter(
     topic, datawriter_qos, NULL, DDS_STATUS_MASK_NONE);
   if (!topic_writer) {
     rmw_set_error_string("failed to create datawriter");
-    return NULL;
+    goto fail;
   }
 
-
-  ConnextStaticPublisherInfo * publisher_info = new ConnextStaticPublisherInfo();
+  // Allocate memory for the ConnextStaticPublisherInfo object.
+  buf = rmw_allocate(sizeof(ConnextStaticPublisherInfo));
+  if (!buf) {
+    rmw_set_error_string("failed to allocate memory");
+    goto fail;
+  }
+  // Use a placement new to construct the ConnextStaticPublisherInfo in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(publisher_info, buf, goto fail, ConnextStaticPublisherInfo)
+  buf = nullptr;  // Only free the publisher_info pointer; don't need the buf pointer anymore.
+  publisher_info->dds_publisher_ = dds_publisher;
   publisher_info->topic_writer_ = topic_writer;
   publisher_info->callbacks_ = callbacks;
 
-  rmw_publisher_t * publisher = new rmw_publisher_t;
   publisher->implementation_identifier = rti_connext_identifier;
   publisher->data = publisher_info;
   return publisher;
+fail:
+  if (publisher) {
+    rmw_publisher_free(publisher);
+  }
+  // Assumption: participant is valid.
+  if (dds_publisher) {
+    if (topic_writer) {
+      if (dds_publisher->delete_datawriter(topic_writer) != DDS_RETCODE_OK) {
+        std::stringstream ss;
+        ss << "leaking datawriter while handling failure at " <<
+          __FILE__ << ":" << __LINE__ << '\n';
+        (std::cerr << ss.str()).flush();
+      }
+    }
+    if (participant->delete_publisher(dds_publisher) != DDS_RETCODE_OK) {
+      std::stringstream ss;
+      ss << "leaking publisher while handling failure at " <<
+        __FILE__ << ":" << __LINE__ << '\n';
+      (std::cerr << ss.str()).flush();
+    }
+  }
+  if (publisher_info) {
+    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+      publisher_info->~ConnextStaticPublisherInfo(), ConnextStaticPublisherInfo)
+    rmw_free(publisher_info);
+  }
+  if (buf) {
+    rmw_free(buf);
+  }
+  return NULL;
+}
+
+rmw_ret_t
+rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
+{
+  if (!node) {
+    rmw_set_error_string("node handle is null");
+    return RMW_RET_ERROR;
+  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  if (!publisher) {
+    rmw_set_error_string("publisher handle is null");
+    return RMW_RET_ERROR;
+  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    publisher handle,
+    publisher->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  DDSDomainParticipant * participant = (DDSDomainParticipant *)node->data;
+  if (!participant) {
+    rmw_set_error_string("participant handle is null");
+    return RMW_RET_ERROR;
+  }
+  // TODO(wjwwood): need to figure out when to unregister types with the participant.
+  ConnextStaticPublisherInfo * publisher_info = (ConnextStaticPublisherInfo *)publisher->data;
+  if (publisher_info) {
+    DDSPublisher * dds_publisher = publisher_info->dds_publisher_;
+    if (dds_publisher) {
+      if (publisher_info->topic_writer_) {
+        if (dds_publisher->delete_datawriter(publisher_info->topic_writer_) != DDS_RETCODE_OK) {
+          rmw_set_error_string("failed to delete datawriter");
+          return RMW_RET_ERROR;
+        }
+      }
+      if (participant->delete_publisher(dds_publisher) != DDS_RETCODE_OK) {
+        rmw_set_error_string("failed to delete publisher");
+        return RMW_RET_ERROR;
+      }
+    } else if (publisher_info->topic_writer_) {
+      rmw_set_error_string("cannot delete datawriter because the publisher is null");
+      return RMW_RET_ERROR;
+    }
+    RMW_TRY_DESTRUCTOR(
+      publisher_info->~ConnextStaticPublisherInfo(),
+      ConnextStaticPublisherInfo, return RMW_RET_ERROR)
+    rmw_free(publisher_info);
+  }
+  publisher->data = nullptr;
+  rmw_publisher_free(publisher);
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t
@@ -321,20 +488,20 @@ rmw_create_subscription(const rmw_node_t * node,
     rmw_set_error_string("node handle is null");
     return NULL;
   }
-  if (node->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("node handle is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return NULL)
+
   if (!type_support) {
     rmw_set_error_string("type support handle is null");
     return NULL;
   }
-  if (type_support->typesupport_identifier !=
-    rosidl_typesupport_connext_cpp::typesupport_connext_identifier)
-  {
-    rmw_set_error_string("type support is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    type support handle,
+    type_support->typesupport_identifier,
+    rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+    return NULL)
 
   DDSDomainParticipant * participant = static_cast<DDSDomainParticipant *>(node->data);
   if (!participant) {
@@ -342,66 +509,78 @@ rmw_create_subscription(const rmw_node_t * node,
     return NULL;
   }
 
-
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(type_support->data);
   if (!callbacks) {
     rmw_set_error_string("callbacks handle is null");
     return NULL;
   }
-  std::string type_name = std::string(callbacks->package_name) + "::msg::dds_::" +
-    callbacks->message_name + "_";
+  std::string type_name = _create_type_name(callbacks, "msg");
+  // Past this point, a failure results in unrolling code in the goto fail block.
+  rmw_subscription_t * subscription = nullptr;
+  bool registered;
+  DDS_SubscriberQos subscriber_qos;
+  DDS_ReturnCode_t status;
+  DDSSubscriber * dds_subscriber = nullptr;
+  DDSTopic * topic;
+  DDSTopicDescription * topic_description = nullptr;
+  DDS_DataReaderQos datareader_qos;
+  DDSDataReader * topic_reader = nullptr;
+  void * buf = nullptr;
+  ConnextStaticSubscriberInfo * subscriber_info = nullptr;
+  // Begin initializing elements.
+  subscription = rmw_subscription_allocate();
+  if (!subscription) {
+    rmw_set_error_string("failed to allocate subscription");
+    goto fail;
+  }
 
-  bool registered = callbacks->register_type(participant, type_name.c_str());
+  registered = callbacks->register_type(participant, type_name.c_str());
   if (!registered) {
     rmw_set_error_string("failed to register type");
-    return NULL;
+    goto fail;
   }
 
-  DDS_SubscriberQos subscriber_qos;
-  DDS_ReturnCode_t status = participant->get_default_subscriber_qos(subscriber_qos);
+  status = participant->get_default_subscriber_qos(subscriber_qos);
   if (status != DDS_RETCODE_OK) {
     rmw_set_error_string("failed to get default subscriber qos");
-    return NULL;
+    goto fail;
   }
 
-  DDSSubscriber * dds_subscriber = participant->create_subscriber(
-    subscriber_qos, NULL, DDS_STATUS_MASK_NONE);
+  dds_subscriber = participant->create_subscriber(subscriber_qos, NULL, DDS_STATUS_MASK_NONE);
   if (!dds_subscriber) {
     rmw_set_error_string("failed to create subscriber");
-    return NULL;
+    goto fail;
   }
 
-  DDSTopic * topic;
-  DDSTopicDescription * topic_description = participant->lookup_topicdescription(topic_name);
+  topic_description = participant->lookup_topicdescription(topic_name);
   if (!topic_description) {
     DDS_TopicQos default_topic_qos;
     status = participant->get_default_topic_qos(default_topic_qos);
     if (status != DDS_RETCODE_OK) {
       rmw_set_error_string("failed to get default topic qos");
-      return NULL;
+      goto fail;
     }
 
     topic = participant->create_topic(
       topic_name, type_name.c_str(), default_topic_qos, NULL, DDS_STATUS_MASK_NONE);
     if (!topic) {
       rmw_set_error_string("failed to create topic");
-      return NULL;
+      goto fail;
     }
   } else {
     DDS_Duration_t timeout = DDS_Duration_t::from_seconds(0);
     topic = participant->find_topic(topic_name, timeout);
     if (!topic) {
       rmw_set_error_string("failed to find topic");
-      return NULL;
+      goto fail;
     }
   }
 
-  DDS_DataReaderQos datareader_qos;
   status = participant->get_default_datareader_qos(datareader_qos);
   if (status != DDS_RETCODE_OK) {
     rmw_set_error_string("failed to get default datareader qos");
-    return NULL;
+    goto fail;
   }
 
   // ensure the history depth is at least the requested queue size
@@ -414,24 +593,119 @@ rmw_create_subscription(const rmw_node_t * node,
     datareader_qos.history.depth = queue_size;
   }
 
-  DDSDataReader * topic_reader = dds_subscriber->create_datareader(
+  topic_reader = dds_subscriber->create_datareader(
     topic, datareader_qos,
     NULL, DDS_STATUS_MASK_NONE);
   if (!topic_reader) {
     rmw_set_error_string("failed to create datareader");
-    return NULL;
+    goto fail;
   }
 
-
-  ConnextStaticSubscriberInfo * subscriber_info = new ConnextStaticSubscriberInfo();
+  // Allocate memory for the ConnextStaticSubscriberInfo object.
+  buf = rmw_allocate(sizeof(ConnextStaticSubscriberInfo));
+  if (!buf) {
+    rmw_set_error_string("failed to allocate memory");
+    goto fail;
+  }
+  // Use a placement new to construct the ConnextStaticSubscriberInfo in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(subscriber_info, buf, goto fail, ConnextStaticSubscriberInfo)
+  buf = nullptr;  // Only free the subscriber_info pointer; don't need the buf pointer anymore.
+  subscriber_info->dds_subscriber_ = dds_subscriber;
   subscriber_info->topic_reader_ = topic_reader;
   subscriber_info->callbacks_ = callbacks;
   subscriber_info->ignore_local_publications = ignore_local_publications;
 
-  rmw_subscription_t * subscription = new rmw_subscription_t;
   subscription->implementation_identifier = rti_connext_identifier;
   subscription->data = subscriber_info;
   return subscription;
+fail:
+  if (subscription) {
+    rmw_subscription_free(subscription);
+  }
+  // Assumption: participant is valid.
+  if (dds_subscriber) {
+    if (topic_reader) {
+      if (dds_subscriber->delete_datareader(topic_reader) != DDS_RETCODE_OK) {
+        std::stringstream ss;
+        ss << "leaking datareader while handling failure at " <<
+          __FILE__ << ":" << __LINE__ << '\n';
+        (std::cerr << ss.str()).flush();
+      }
+    }
+    if (participant->delete_subscriber(dds_subscriber) != DDS_RETCODE_OK) {
+      std::stringstream ss;
+      std::cerr << "leaking subscriber while handling failure at " <<
+        __FILE__ << ":" << __LINE__ << '\n';
+      (std::cerr << ss.str()).flush();
+    }
+  }
+  if (subscriber_info) {
+    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+      subscriber_info->~ConnextStaticSubscriberInfo(), ConnextStaticSubscriberInfo)
+    rmw_free(subscriber_info);
+  }
+  if (buf) {
+    rmw_free(buf);
+  }
+  return NULL;
+}
+
+rmw_ret_t
+rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
+{
+  if (!node) {
+    rmw_set_error_string("node handle is null");
+    return RMW_RET_ERROR;
+  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  if (!subscription) {
+    rmw_set_error_string("subscription handle is null");
+    return RMW_RET_ERROR;
+  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription handle,
+    subscription->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  DDSDomainParticipant * participant = (DDSDomainParticipant *)node->data;
+  if (!participant) {
+    rmw_set_error_string("participant handle is null");
+    return RMW_RET_ERROR;
+  }
+  // TODO(wjwwood): need to figure out when to unregister types with the participant.
+  ConnextStaticSubscriberInfo * subscriber_info =
+    (ConnextStaticSubscriberInfo *)subscription->data;
+  if (subscriber_info) {
+    auto dds_subscriber = subscriber_info->dds_subscriber_;
+    if (dds_subscriber) {
+      auto topic_reader = subscriber_info->topic_reader_;
+      if (topic_reader) {
+        if (dds_subscriber->delete_datareader(topic_reader) != DDS_RETCODE_OK) {
+          rmw_set_error_string("failed to delete datareader");
+          return RMW_RET_ERROR;
+        }
+      }
+      if (participant->delete_subscriber(dds_subscriber) != DDS_RETCODE_OK) {
+        rmw_set_error_string("failed to delete subscriber");
+        return RMW_RET_ERROR;
+      }
+    } else if (subscriber_info->topic_reader_) {
+      rmw_set_error_string("cannot delete datareader because the subscriber is null");
+      return RMW_RET_ERROR;
+    }
+    RMW_TRY_DESTRUCTOR(
+      subscriber_info->~ConnextStaticSubscriberInfo(),
+      ConnextStaticSubscriberInfo, return RMW_RET_ERROR)
+    rmw_free(subscriber_info);
+  }
+  subscription->data = nullptr;
+  rmw_subscription_free(subscription);
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t
@@ -441,10 +715,11 @@ rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * tak
     rmw_set_error_string("subscription handle is null");
     return RMW_RET_ERROR;
   }
-  if (subscription->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("subscriber handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription handle,
+    subscription->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
   if (!ros_message) {
     rmw_set_error_string("ros message handle is null");
     return RMW_RET_ERROR;
@@ -480,10 +755,32 @@ rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * tak
 rmw_guard_condition_t *
 rmw_create_guard_condition()
 {
-  rmw_guard_condition_t * guard_condition = new rmw_guard_condition_t;
+  rmw_guard_condition_t * guard_condition = rmw_guard_condition_allocate();
+  if (!guard_condition) {
+    rmw_set_error_string("failed to allocate guard condition");
+    return NULL;
+  }
+  // Allocate memory for the DDSGuardCondition object.
+  DDSGuardCondition * dds_guard_condition = nullptr;
+  void * buf = rmw_allocate(sizeof(DDSGuardCondition));
+  if (!buf) {
+    rmw_set_error_string("failed to allocate memory");
+    goto fail;
+  }
+  // Use a placement new to construct the DDSGuardCondition in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(dds_guard_condition, buf, goto fail, DDSGuardCondition)
+  buf = nullptr;  // Only free the dds_guard_condition pointer; don't need the buf pointer anymore.
   guard_condition->implementation_identifier = rti_connext_identifier;
   guard_condition->data = new DDSGuardCondition();
   return guard_condition;
+fail:
+  if (guard_condition) {
+    rmw_guard_condition_free(guard_condition);
+  }
+  if (buf) {
+    rmw_free(buf);
+  }
+  return NULL;
 }
 
 rmw_ret_t
@@ -493,10 +790,17 @@ rmw_destroy_guard_condition(rmw_guard_condition_t * guard_condition)
     rmw_set_error_string("guard condition handle is null");
     return RMW_RET_ERROR;
   }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    guard condition handle,
+    guard_condition->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
 
-  delete (DDSGuardCondition *)guard_condition->data;
-  delete guard_condition;
-  return RMW_RET_OK;
+  auto result = RMW_RET_OK;
+  RMW_TRY_DESTRUCTOR(
+    ((DDSGuardCondition *)guard_condition->data)->~DDSGuardCondition(),
+    DDSGuardCondition, result = RMW_RET_ERROR)
+  rmw_guard_condition_free(guard_condition);
+  return result;
 }
 
 rmw_ret_t
@@ -506,10 +810,10 @@ rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition_handle
     rmw_set_error_string("guard condition handle is null");
     return RMW_RET_ERROR;
   }
-  if (guard_condition_handle->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("guard condition handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    guard condition handle,
+    guard_condition_handle->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
 
   DDSGuardCondition * guard_condition =
     static_cast<DDSGuardCondition *>(guard_condition_handle->data);
@@ -797,20 +1101,20 @@ rmw_create_client(
     rmw_set_error_string("node handle is null");
     return NULL;
   }
-  if (node->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("node handle is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return NULL)
+
   if (!type_support) {
     rmw_set_error_string("type support handle is null");
     return NULL;
   }
-  if (type_support->typesupport_identifier !=
-    rosidl_typesupport_connext_cpp::typesupport_connext_identifier)
-  {
-    rmw_set_error_string("type support is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    type support handle,
+    type_support->typesupport_identifier,
+    rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+    return NULL)
 
   DDSDomainParticipant * participant = static_cast<DDSDomainParticipant *>(node->data);
   if (!participant) {
@@ -824,28 +1128,66 @@ rmw_create_client(
     rmw_set_error_string("callbacks handle is null");
     return NULL;
   }
-
-  DDSDataReader * response_datareader;
-  void * requester = callbacks->create_requester(
+  // Past this point, a failure results in unrolling code in the goto fail block.
+  rmw_client_t * client = nullptr;
+  DDSDataReader * response_datareader = nullptr;
+  void * requester = nullptr;
+  void * buf = nullptr;
+  ConnextStaticClientInfo * client_info = nullptr;
+  // Begin inializing elements.
+  client = rmw_client_allocate();
+  if (!client) {
+    rmw_set_error_string("failed to allocate client");
+    goto fail;
+  }
+  requester = callbacks->create_requester(
     participant, service_name, reinterpret_cast<void **>(&response_datareader));
   if (!requester) {
     rmw_set_error_string("failed to create requester");
-    return NULL;
+    goto fail;
   }
   if (!response_datareader) {
     rmw_set_error_string("data reader handle is null");
-    return NULL;
+    goto fail;
   }
 
-  ConnextStaticClientInfo * client_info = new ConnextStaticClientInfo();
+  buf = rmw_allocate(sizeof(ConnextStaticClientInfo));
+  if (!buf) {
+    rmw_set_error_string("failed to allocate memory");
+    goto fail;
+  }
+  // Use a placement new to construct the ConnextStaticClientInfo in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(client_info, buf, goto fail, ConnextStaticClientInfo)
+  buf = nullptr;  // Only free the client_info pointer; don't need the buf pointer anymore.
   client_info->requester_ = requester;
   client_info->callbacks_ = callbacks;
   client_info->response_datareader_ = response_datareader;
 
-  rmw_client_t * client = new rmw_client_t;
   client->implementation_identifier = rti_connext_identifier;
   client->data = client_info;
   return client;
+fail:
+  if (client) {
+    rmw_client_free(client);
+  }
+  if (response_datareader) {
+    if (participant->delete_datareader(response_datareader) != DDS_RETCODE_OK) {
+      std::stringstream ss;
+      ss << "leaking datareader while handling failure at " <<
+        __FILE__ << ":" << __LINE__ << '\n';
+      (std::cerr << ss.str()).flush();
+    }
+  }
+  // TODO(wjwwood): deallocate requester (currently allocated with new elsewhere)
+  if (client_info) {
+    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+      client_info->~ConnextStaticClientInfo(), ConnextStaticClientInfo)
+    rmw_free(client_info);
+  }
+  if (buf) {
+    rmw_free(buf);
+  }
+  return NULL;
 }
 
 rmw_ret_t
@@ -855,11 +1197,19 @@ rmw_destroy_client(rmw_client_t * client)
     rmw_set_error_string("client handle is null");
     return RMW_RET_ERROR;
   }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client handle,
+    client->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
 
+  auto result = RMW_RET_OK;
   // TODO(esteve): de-allocate Requester and response DataReader
-  delete static_cast<ConnextStaticClientInfo *>(client->data);
-  delete client;
-  return RMW_RET_OK;
+  RMW_TRY_DESTRUCTOR(
+    static_cast<ConnextStaticClientInfo *>(client->data)->~ConnextStaticClientInfo(),
+    ConnextStaticClientInfo,
+    result = RMW_RET_ERROR)
+  rmw_client_free(client);
+  return result;
 }
 
 rmw_ret_t
@@ -872,10 +1222,11 @@ rmw_send_request(
     rmw_set_error_string("client handle is null");
     return RMW_RET_ERROR;
   }
-  if (client->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("client handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client handle,
+    client->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
   if (!ros_request) {
     rmw_set_error_string("ros request handle is null");
     return RMW_RET_ERROR;
@@ -911,20 +1262,20 @@ rmw_create_service(
     rmw_set_error_string("node handle is null");
     return NULL;
   }
-  if (node->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("node handle is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node handle,
+    node->implementation_identifier, rti_connext_identifier,
+    return NULL)
+
   if (!type_support) {
     rmw_set_error_string("type support handle is null");
     return NULL;
   }
-  if (type_support->typesupport_identifier !=
-    rosidl_typesupport_connext_cpp::typesupport_connext_identifier)
-  {
-    rmw_set_error_string("type support is not from this rmw implementation");
-    return NULL;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    type support handle,
+    type_support->typesupport_identifier,
+    rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+    return NULL)
 
   DDSDomainParticipant * participant = static_cast<DDSDomainParticipant *>(node->data);
   if (!participant) {
@@ -938,33 +1289,65 @@ rmw_create_service(
     rmw_set_error_string("callbacks handle is null");
     return NULL;
   }
-
-  DDSDataReader * request_datareader;
-
-  void * replier = callbacks->create_replier(
+  // Past this point, a failure results in unrolling code in the goto fail block.
+  DDSDataReader * request_datareader = nullptr;
+  void * replier = nullptr;
+  void * buf = nullptr;
+  ConnextStaticServiceInfo * service_info = nullptr;
+  rmw_service_t * service = nullptr;
+  // Begin initializing elements.
+  service = rmw_service_allocate();
+  if (!service) {
+    rmw_set_error_string("service handle is null");
+    goto fail;
+  }
+  replier = callbacks->create_replier(
     participant, service_name, reinterpret_cast<void **>(&request_datareader));
   if (!replier) {
     rmw_set_error_string("failed to create replier");
-    return NULL;
+    goto fail;
   }
   if (!request_datareader) {
     rmw_set_error_string("data reader handle is null");
-    return NULL;
+    goto fail;
   }
 
-  ConnextStaticServiceInfo * service_info = new ConnextStaticServiceInfo();
+  buf = rmw_allocate(sizeof(ConnextStaticServiceInfo));
+  if (!buf) {
+    rmw_set_error_string("failed to allocate memory");
+    goto fail;
+  }
+  // Use a placement new to construct the ConnextStaticServiceInfo in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(service_info, buf, goto fail, ConnextStaticServiceInfo)
+  buf = nullptr;  // Only free the service_info pointer; don't need the buf pointer anymore.
   service_info->replier_ = replier;
   service_info->callbacks_ = callbacks;
   service_info->request_datareader_ = request_datareader;
 
-  rmw_service_t * service = rmw_service_allocate();
-  if (!service) {
-    rmw_set_error_string("service handle is null");
-    return NULL;
-  }
   service->implementation_identifier = rti_connext_identifier;
   service->data = service_info;
   return service;
+fail:
+  if (service) {
+    rmw_service_free(service);
+  }
+  if (request_datareader) {
+    if (participant->delete_datareader(request_datareader) != RMW_RET_OK) {
+      std::stringstream ss;
+      ss << "leaking datareader while handling failure at " <<
+        __FILE__ << ":" << __LINE__ << '\n';
+      (std::cerr << ss.str()).flush();
+    }
+  }
+  if (service_info) {
+    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+      service_info->~ConnextStaticServiceInfo(), ConnextStaticServiceInfo)
+    rmw_free(service_info);
+  }
+  if (buf) {
+    rmw_free(buf);
+  }
+  return NULL;
 }
 
 rmw_ret_t
@@ -974,11 +1357,19 @@ rmw_destroy_service(rmw_service_t * service)
     rmw_set_error_string("service handle is null");
     return RMW_RET_ERROR;
   }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service handle,
+    service->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
 
+  auto result = RMW_RET_OK;
   // TODO(esteve): de-allocate Replier and request DataReader
-  delete static_cast<ConnextStaticServiceInfo *>(service->data);
-  delete service;
-  return RMW_RET_OK;
+  RMW_TRY_DESTRUCTOR(
+    static_cast<ConnextStaticServiceInfo *>(service->data)->~ConnextStaticServiceInfo(),
+    ConnextStaticServiceInfo,
+    result = RMW_RET_ERROR)
+  rmw_service_free(service);
+  return result;
 }
 
 rmw_ret_t
@@ -992,10 +1383,11 @@ rmw_take_request(
     rmw_set_error_string("service handle is null");
     return RMW_RET_ERROR;
   }
-  if (service->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("service handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service handle,
+    service->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
   if (!ros_request_header) {
     rmw_set_error_string("ros request header handle is null");
     return RMW_RET_ERROR;
@@ -1044,10 +1436,11 @@ rmw_take_response(
     rmw_set_error_string("client handle is null");
     return RMW_RET_ERROR;
   }
-  if (client->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("client handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client handle,
+    client->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
   if (!ros_request_header) {
     rmw_set_error_string("ros request header handle is null");
     return RMW_RET_ERROR;
@@ -1095,10 +1488,11 @@ rmw_send_response(
     rmw_set_error_string("service handle is null");
     return RMW_RET_ERROR;
   }
-  if (service->implementation_identifier != rti_connext_identifier) {
-    rmw_set_error_string("service handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service handle,
+    service->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
   if (!ros_request_header) {
     rmw_set_error_string("ros request header handle is null");
     return RMW_RET_ERROR;

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
@@ -74,10 +74,6 @@ register_type__@(spec.base_type.type)(
   DDS_ReturnCode_t status =
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_TypeSupport::register_type(participant, type_name);
 
-  // DDS_TypeCode * type_code = @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)__get_typecode();
-  // DDS_ExceptionCode_t ex;
-  // type_code->print_IDL(1, ex);
-
   return status == DDS_RETCODE_OK;
 }
 

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
@@ -59,6 +59,7 @@ void * create_requester__@(spec.srv_name)(
   connext::RequesterParams requester_params(participant);
   requester_params.service_name(service_name);
 
+  // TODO(wjwwood): use rmw allocators for this.
   connext::Requester<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> * requester(new connext::Requester<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_>(requester_params));
 
   *untyped_reader = requester->get_reply_datareader();
@@ -93,6 +94,7 @@ void * create_replier__@(spec.srv_name)(
   connext::ReplierParams<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> replier_params(participant);
   replier_params.service_name(service_name);
 
+  // TODO(wjwwood): use rmw allocators for this.
   connext::Replier<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> * replier(new connext::Replier<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_>(replier_params));
 
   *untyped_reader = replier->get_request_datareader();


### PR DESCRIPTION
This has been done to resolve some teardown related errors and generally to improve the state of memory management in these implementations.

I've done several things here:

- Implemented destroy functions where they were missing before.
- Refactored create functions to properly unroll actions which had already been made in the event of an error later in the create function. This uses the "goto fail" pattern that is popular in the Linux kernel.
- Wrapped C++ constructor and destructor calls in try-catch cases to prevent escalation of exceptions through the C api.
- Replaced use of new and delete where ever possible with rmw_allocate to allow us more control over allocation in the future.
- Other minor improvements.

Things that are yet to be done (covered by TODO's):

- Some error propagation is not possible in the current setup (or error strings may get overwritten by other errors before returning).
- I think we might be leaking calls to `register_type` on the participant, but it's not clear if we must unregister them or if so, when we should unregister them.
- Servers and clients new more, msg specific, refactoring to replace use of new and (currently missing) delete calls to create "repliers" and "requesters".

Connects ros2/ros2#69