### PR TITLE
make typesupport namespace unique for each rmw implementation

### DIFF
--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
@@ -41,7 +41,7 @@ namespace dds_
 {
 struct @(field.type.type)_;
 }  // namespace dds_
-namespace type_support
+namespace typesupport_connext_cpp
 {
 bool convert_ros_message_to_dds(
   const @(field.type.pkg_name)::msg::@(field.type.type) &,
@@ -49,7 +49,7 @@ bool convert_ros_message_to_dds(
 bool convert_dds_message_to_ros(
   const @(field.type.pkg_name)::msg::dds_::@(field.type.type)_ &,
   @(field.type.pkg_name)::msg::@(field.type.type) &);
-}  // namespace type_support
+}  // namespace typesupport_connext_cpp
 }  // namespace msg
 }  // namespace @(field.type.pkg_name)
 
@@ -62,7 +62,7 @@ namespace @(spec.base_type.pkg_name)
 namespace @(subfolder)
 {
 
-namespace type_support
+namespace typesupport_connext_cpp
 {
 
 bool
@@ -109,7 +109,7 @@ convert_ros_message_to_dds(
         ros_message.@(field.name)[i];
 @[else]@
       if (
-        !@(field.type.pkg_name)::msg::type_support::convert_ros_message_to_dds(
+        !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_ros_message_to_dds(
           ros_message.@(field.name)[i],
           dds_message.@(field.name)_[i]))
       {
@@ -127,7 +127,7 @@ convert_ros_message_to_dds(
     ros_message.@(field.name);
 @[else]@
   if (
-    !@(field.type.pkg_name)::msg::type_support::convert_ros_message_to_dds(
+    !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_ros_message_to_dds(
       ros_message.@(field.name),
       dds_message.@(field.name)_))
   {
@@ -190,7 +190,7 @@ convert_dds_message_to_ros(
         dds_message.@(field.name)_[i];
 @[else]@
       if (
-        !@(field.type.pkg_name)::msg::type_support::convert_dds_message_to_ros(
+        !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_dds_message_to_ros(
           dds_message.@(field.name)_[i],
           ros_message.@(field.name)[i]))
       {
@@ -204,7 +204,7 @@ convert_dds_message_to_ros(
     dds_message.@(field.name)_;
 @[else]@
   if (
-    !@(field.type.pkg_name)::msg::type_support::convert_dds_message_to_ros(
+    !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_dds_message_to_ros(
       dds_message.@(field.name)_,
       ros_message.@(field.name)))
   {
@@ -303,7 +303,7 @@ static rosidl_message_type_support_t handle = {
   &callbacks
 };
 
-}  // namespace type_support
+}  // namespace typesupport_connext_cpp
 
 }  // namespace @(subfolder)
 
@@ -317,7 +317,7 @@ ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
 const rosidl_message_type_support_t *
 get_message_type_support_handle_connext<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
 {
-  return &@(spec.base_type.pkg_name)::@(subfolder)::type_support::handle;
+  return &@(spec.base_type.pkg_name)::@(subfolder)::typesupport_connext_cpp::handle;
 }
 
 }  // namespace rosidl_typesupport_connext_cpp

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.hpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.hpp.template
@@ -31,7 +31,7 @@ namespace @(spec.base_type.pkg_name)
 namespace @(subfolder)
 {
 
-namespace type_support
+namespace typesupport_connext_cpp
 {
 
 bool
@@ -63,7 +63,7 @@ take__@(spec.base_type.type)(
   void * untyped_ros_message,
   bool * taken);
 
-}  // namespace type_support
+}  // namespace typesupport_connext_cpp
 
 }  // namespace @(subfolder)
 

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
@@ -43,7 +43,7 @@ namespace @(spec.pkg_name)
 namespace srv
 {
 
-namespace type_support
+namespace typesupport_connext_cpp
 {
 
 void * create_requester__@(spec.srv_name)(
@@ -72,7 +72,7 @@ int64_t send_request__@(spec.srv_name)(
 {
   connext::WriteSample<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_> request;
   const @(spec.pkg_name)::srv::@(spec.srv_name)_Request & ros_request = *(reinterpret_cast<const @(spec.pkg_name)::srv::@(spec.srv_name)_Request *>(untyped_ros_request));
-  @(spec.pkg_name)::srv::type_support::convert_ros_message_to_dds(ros_request, request.data());
+  @(spec.pkg_name)::srv::typesupport_connext_cpp::convert_ros_message_to_dds(ros_request, request.data());
 
   connext::Requester<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> * requester = reinterpret_cast<connext::Requester<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Request_, @(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> *>(untyped_requester);
 
@@ -125,7 +125,7 @@ bool take_request__@(spec.srv_name)(
   }
 
   bool converted =
-    @(spec.pkg_name)::srv::type_support::convert_dds_message_to_ros(request.data(), ros_request);
+    @(spec.pkg_name)::srv::typesupport_connext_cpp::convert_dds_message_to_ros(request.data(), ros_request);
   if (!converted) {
     return false;
   }
@@ -166,7 +166,7 @@ bool take_response__@(spec.srv_name)(
   req_id.sequence_number = sequence_number;
 
   bool converted =
-    @(spec.pkg_name)::srv::type_support::convert_dds_message_to_ros(response.data(), ros_response);
+    @(spec.pkg_name)::srv::typesupport_connext_cpp::convert_dds_message_to_ros(response.data(), ros_response);
   return converted;
 }
 
@@ -182,7 +182,7 @@ bool send_response__@(spec.srv_name)(
   connext::WriteSample<@(spec.pkg_name)::srv::dds_::@(spec.srv_name)_Response_> response;
   const @(spec.pkg_name)::srv::@(spec.srv_name)_Response & ros_response = *(reinterpret_cast<const @(spec.pkg_name)::srv::@(spec.srv_name)_Response *>(untyped_ros_response));
   bool converted =
-    @(spec.pkg_name)::srv::type_support::convert_ros_message_to_dds(ros_response, response.data());
+    @(spec.pkg_name)::srv::typesupport_connext_cpp::convert_ros_message_to_dds(ros_response, response.data());
   if (!converted) {
     return false;
   }
@@ -219,7 +219,7 @@ static rosidl_service_type_support_t handle = {
   &callbacks
 };
 
-}  // namespace type_support
+}  // namespace typesupport_connext_cpp
 
 }  // namespace srv
 
@@ -233,7 +233,7 @@ ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
 const rosidl_service_type_support_t *
 get_service_type_support_handle_connext<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
-  return &@(spec.pkg_name)::srv::type_support::handle;
+  return &@(spec.pkg_name)::srv::typesupport_connext_cpp::handle;
 }
 
 }  // namespace rosidl_typesupport_connext_cpp


### PR DESCRIPTION
Otherwise message lib A from type support X might use symbols from message B from type support Y.