### PR TITLE
fix warnings

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -19,15 +19,19 @@
 #include <stdexcept>
 #include <string>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#ifdef __clang__
-# pragma clang diagnostic ignored "-Wdeprecated-register"
-# pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include <ndds/ndds_cpp.h>
 #include <ndds/ndds_requestreply_cpp.h>
-#pragma GCC diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <rmw/rmw.h>
 #include <rmw/allocators.h>

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -372,7 +373,12 @@ rmw_create_publisher(
     static_cast<size_t>(datawriter_qos.history.depth) < queue_size
   )
   {
-    datawriter_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS_Long>::max)()) {
+      RMW_SET_ERROR_MSG(
+        "failed to set history depth since the requested queue size exceeds the DDS type");
+      goto fail;
+    }
+    datawriter_qos.history.depth = static_cast<DDS_Long>(queue_size);
   }
 
   topic_writer = dds_publisher->create_datawriter(
@@ -641,7 +647,12 @@ rmw_create_subscription(const rmw_node_t * node,
     static_cast<size_t>(datareader_qos.history.depth) < queue_size
   )
   {
-    datareader_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS_Long>::max)()) {
+      RMW_SET_ERROR_MSG(
+        "failed to set history depth since the requested queue size exceeds the DDS type");
+      goto fail;
+    }
+    datareader_qos.history.depth = static_cast<DDS_Long>(queue_size);
   }
 
   topic_reader = dds_subscriber->create_datareader(
@@ -892,7 +903,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   DDSWaitSet waitset;
 
   // add a condition for each subscriber
-  for (unsigned long i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
     ConnextStaticSubscriberInfo * subscriber_info =
       static_cast<ConnextStaticSubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {
@@ -922,7 +933,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // add a condition for each guard condition
-  for (unsigned long i = 0; i < guard_conditions->guard_condition_count; ++i) {
+  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
     DDSGuardCondition * guard_condition =
       static_cast<DDSGuardCondition *>(guard_conditions->guard_conditions[i]);
     if (!guard_condition) {
@@ -937,7 +948,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // add a condition for each service
-  for (unsigned long i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count; ++i) {
     ConnextStaticServiceInfo * service_info =
       static_cast<ConnextStaticServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -967,7 +978,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // add a condition for each client
-  for (unsigned long i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count; ++i) {
     ConnextStaticClientInfo * client_info =
       static_cast<ConnextStaticClientInfo *>(clients->clients[i]);
     if (!client_info) {
@@ -1015,7 +1026,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // set subscriber handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
     ConnextStaticSubscriberInfo * subscriber_info =
       static_cast<ConnextStaticSubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {
@@ -1048,7 +1059,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // set guard condition handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < guard_conditions->guard_condition_count; ++i) {
+  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
     DDSCondition * condition =
       static_cast<DDSCondition *>(guard_conditions->guard_conditions[i]);
     if (!condition) {
@@ -1077,7 +1088,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // set service handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count; ++i) {
     ConnextStaticServiceInfo * service_info =
       static_cast<ConnextStaticServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -1110,7 +1121,7 @@ rmw_wait(rmw_subscriptions_t * subscriptions,
   }
 
   // set client handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count; ++i) {
     ConnextStaticClientInfo * client_info =
       static_cast<ConnextStaticClientInfo *>(clients->clients[i]);
     if (!client_info) {

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -20,17 +20,21 @@
 #include <string>
 #include <vector>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#ifdef __clang__
-# pragma clang diagnostic ignored "-Wdeprecated-register"
-# pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include <ndds/connext_cpp/connext_cpp_replier_details.h>
 #include <ndds/connext_cpp/connext_cpp_requester_details.h>
 #include <ndds/ndds_cpp.h>
 #include <ndds/ndds_requestreply_cpp.h>
-#pragma GCC diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <rmw/allocators.h>
 #include <rmw/error_handling.h>
@@ -1684,14 +1688,14 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
           auto ros_values = \
             reinterpret_cast<TYPE *>(static_cast<char *>(ros_message) + member->offset_); \
           for (size_t i = 0; i < array_size; ++i) { \
-            ros_values[i] = values[i]; \
+            ros_values[i] = values[i] == DDS_BOOLEAN_TRUE; \
           } \
         } else { \
           void * untyped_vector = static_cast<char *>(ros_message) + member->offset_; \
           auto vector = static_cast<std::vector<TYPE> *>(untyped_vector); \
           vector->resize(array_size); \
           for (size_t i = 0; i < array_size; ++i) { \
-            (*vector)[i] = values[i]; \
+            (*vector)[i] = values[i] == DDS_BOOLEAN_TRUE; \
           } \
         } \
         rmw_free(values); \
@@ -1707,7 +1711,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
         return false; \
       } \
       auto ros_value = reinterpret_cast<TYPE *>(static_cast<char *>(ros_message) + member->offset_); \
-      *ros_value = value; \
+      *ros_value = value == DDS_BOOLEAN_TRUE; \
     } \
   }
 

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -261,7 +262,12 @@ DDS_TypeCode * create_type_code(
         {
           DDS_UnsignedLong max_string_size;
           if (member->string_upper_bound_) {
-            max_string_size = member->string_upper_bound_;
+            if (member->string_upper_bound_ > (std::numeric_limits<DDS_UnsignedLong>::max)()) {
+              RMW_SET_ERROR_MSG(
+                "failed to create string typecode since the upper bound exceeds the DDS type");
+              goto fail;
+            }
+            max_string_size = static_cast<DDS_UnsignedLong>(member->string_upper_bound_);
           } else {
             // TODO use std::string().max_size() as soon as Connext supports dynamic allocation
             max_string_size = 255;
@@ -306,9 +312,13 @@ DDS_TypeCode * create_type_code(
     }
     if (member->is_array_) {
       if (member->array_size_) {
+        if (member->array_size_ > (std::numeric_limits<DDS_UnsignedLong>::max)()) {
+          RMW_SET_ERROR_MSG("failed to create array typecode since the size exceeds the DDS type");
+          goto fail;
+        }
+        DDS_UnsignedLong array_size = static_cast<DDS_UnsignedLong>(member->array_size_);
         if (!member->is_upper_bound_) {
-          member_type_code_non_const =
-            factory->create_array_tc(member->array_size_, member_type_code, ex);
+          member_type_code_non_const = factory->create_array_tc(array_size, member_type_code, ex);
           member_type_code = member_type_code_non_const;
           if (!member_type_code || ex != DDS_NO_EXCEPTION_CODE) {
             RMW_SET_ERROR_MSG("failed to create array typecode");
@@ -316,7 +326,7 @@ DDS_TypeCode * create_type_code(
           }
         } else {
           member_type_code_non_const =
-            factory->create_sequence_tc(member->array_size_, member_type_code, ex);
+            factory->create_sequence_tc(array_size, member_type_code, ex);
           member_type_code = member_type_code_non_const;
           if (!member_type_code || ex != DDS_NO_EXCEPTION_CODE) {
             RMW_SET_ERROR_MSG("failed to create sequence typecode");
@@ -594,7 +604,11 @@ rmw_create_publisher(
     static_cast<size_t>(datawriter_qos.history.depth) < queue_size
   )
   {
-    datawriter_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS_Long>::max)()) {
+      RMW_SET_ERROR_MSG("requested queue size exceeds maximum DDS history depth");
+      goto fail;
+    }
+    datawriter_qos.history.depth = static_cast<DDS_Long>(queue_size);
   }
 
   topic_writer = dds_publisher->create_datawriter(
@@ -844,7 +858,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
         NULL, \
         i + 1, \
-        array_size, \
+        static_cast<DDS_UnsignedLong>(array_size), \
         ros_values); \
       if (status != DDS_RETCODE_OK) { \
         RMW_SET_ERROR_MSG("failed to set array value using " #ARRAY_METHOD_NAME); \
@@ -873,7 +887,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
         NULL, \
         i + 1, \
-        array_size, \
+        static_cast<DDS_UnsignedLong>(array_size), \
         values); \
       rmw_free(values); \
       if (status != DDS_RETCODE_OK) { \
@@ -906,6 +920,11 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
         const void * untyped_vector = static_cast<const char *>(ros_message) + member->offset_; \
         auto vector = static_cast<const std::vector<TYPE> *>(untyped_vector); \
         array_size = vector->size(); \
+        if (array_size > (std::numeric_limits<DDS_UnsignedLong>::max)()) { \
+          RMW_SET_ERROR_MSG( \
+            "failed to set values since the requested array size exceeds the DDS type"); \
+          return false; \
+        } \
         if (array_size > 0) { \
           values = static_cast<DDS_TYPE *>(rmw_allocate(sizeof(DDS_TYPE) * array_size)); \
           if (!values) { \
@@ -920,7 +939,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
         NULL, \
         i + 1, \
-        array_size, \
+        static_cast<DDS_UnsignedLong>(array_size), \
         values); \
       rmw_free(values); \
       if (status != DDS_RETCODE_OK) { \
@@ -939,7 +958,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       DDS_ReturnCode_t status = dynamic_data->bind_complex_member( \
         dynamic_data_member, \
         NULL, \
-        i + 1); \
+        static_cast<DDS_DynamicDataMemberId>(i + 1)); \
       if (status != DDS_RETCODE_OK) { \
         RMW_SET_ERROR_MSG("failed to bind complex member"); \
         return false; \
@@ -965,7 +984,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
         reinterpret_cast<const TYPE *>(static_cast<const char *>(ros_message) + member->offset_); \
       DDS_ReturnCode_t status = dynamic_data->METHOD_NAME( \
         NULL, \
-        i + 1, \
+        static_cast<DDS_DynamicDataMemberId>(i + 1), \
         value->c_str()); \
       if (status != DDS_RETCODE_OK) { \
         RMW_SET_ERROR_MSG("failed to set value using " #METHOD_NAME); \
@@ -979,7 +998,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
   DDS_ReturnCode_t status = dynamic_data->bind_complex_member( \
     sub_dynamic_data, \
     NULL, \
-    i + 1); \
+    static_cast<DDS_DynamicDataMemberId>(i + 1)); \
   if (status != DDS_RETCODE_OK) { \
     RMW_SET_ERROR_MSG("failed to bind complex member"); \
     return false; \
@@ -1345,7 +1364,11 @@ rmw_create_subscription(
     static_cast<size_t>(datareader_qos.history.depth) < queue_size
   )
   {
-    datareader_qos.history.depth = queue_size;
+    if (queue_size > (std::numeric_limits<DDS_Long>::max)()) {
+      RMW_SET_ERROR_MSG("requested queue size exceeds maximum DDS history depth");
+      goto fail;
+    }
+    datareader_qos.history.depth = static_cast<DDS_Long>(queue_size);
   }
 
   topic_reader = dds_subscriber->create_datareader(
@@ -1596,7 +1619,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
     if (member->is_array_) { \
       ARRAY_SIZE() \
       ARRAY_RESIZE_AND_VALUES(TYPE) \
-      DDS_UnsignedLong length = array_size; \
+      DDS_UnsignedLong length = static_cast<DDS_UnsignedLong>(array_size); \
       DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
         ros_values, \
         &length, \
@@ -1631,7 +1654,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
           RMW_SET_ERROR_MSG("failed to allocate memory"); \
           return false; \
         } \
-        DDS_UnsignedLong length = array_size; \
+        DDS_UnsignedLong length = static_cast<DDS_UnsignedLong>(array_size); \
         DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
           values, \
           &length, \
@@ -1673,7 +1696,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
           RMW_SET_ERROR_MSG("failed to allocate memory"); \
           return false; \
         } \
-        DDS_UnsignedLong length = array_size; \
+        DDS_UnsignedLong length = static_cast<DDS_UnsignedLong>(array_size); \
         DDS_ReturnCode_t status = dynamic_data->ARRAY_METHOD_NAME( \
           values, \
           &length, \
@@ -1724,7 +1747,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       DDS_ReturnCode_t status = dynamic_data->bind_complex_member( \
         dynamic_data_member, \
         NULL, \
-        i + 1); \
+        static_cast<DDS_DynamicDataMemberId>(i + 1)); \
       if (status != DDS_RETCODE_OK) { \
         RMW_SET_ERROR_MSG("failed to bind complex member"); \
         return false; \
@@ -1762,7 +1785,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
         value, \
         &size, \
         NULL, \
-        i + 1); \
+        static_cast<DDS_DynamicDataMemberId>(i + 1)); \
       if (status != DDS_RETCODE_OK) { \
         if (value) { \
           delete[] value; \
@@ -1783,7 +1806,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   DDS_ReturnCode_t status = dynamic_data->bind_complex_member( \
     sub_dynamic_data, \
     NULL, \
-    i + 1); \
+    static_cast<DDS_DynamicDataMemberId>(i + 1)); \
   if (status != DDS_RETCODE_OK) { \
     RMW_SET_ERROR_MSG("failed to bind complex member"); \
     return false; \
@@ -2131,7 +2154,7 @@ rmw_wait(
   DDSWaitSet waitset;
 
   // add a condition for each subscriber
-  for (unsigned long i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
     CustomSubscriberInfo * subscriber_info =
       static_cast<CustomSubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {
@@ -2161,7 +2184,7 @@ rmw_wait(
   }
 
   // add a condition for each guard condition
-  for (unsigned long i = 0; i < guard_conditions->guard_condition_count; ++i) {
+  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
     DDSGuardCondition * guard_condition =
       static_cast<DDSGuardCondition *>(guard_conditions->guard_conditions[i]);
     if (!guard_condition) {
@@ -2176,7 +2199,7 @@ rmw_wait(
   }
 
   // add a condition for each service
-  for (unsigned long i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count; ++i) {
     ConnextDynamicServiceInfo * service_info =
       static_cast<ConnextDynamicServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -2206,7 +2229,7 @@ rmw_wait(
   }
 
   // add a condition for each client
-  for (unsigned long i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count; ++i) {
     ConnextDynamicClientInfo * client_info =
       static_cast<ConnextDynamicClientInfo *>(clients->clients[i]);
     if (!client_info) {
@@ -2254,7 +2277,7 @@ rmw_wait(
   }
 
   // set subscriber handles to zero for all not triggered conditions
-  for (unsigned long i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
     CustomSubscriberInfo * subscriber_info =
       static_cast<CustomSubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -171,10 +171,17 @@ endif()
 if(NOT WIN32)
   set(_target_compile_flags "-Wall -Wextra")
 else()
-  set(_target_compile_flags "/W4")
+  set(_target_compile_flags
+    "/W4"
+    "/wd4100"
+    "/wd4127"
+    "/wd4275"
+    "/wd4458"
+  )
 endif()
+string(REPLACE ";" " " _target_compile_flags "${_target_compile_flags}")
 set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  PROPERTIES COMPILE_FLAGS "${_target_compile_flags}")
+  PROPERTIES COMPILE_FLAGS ${_target_compile_flags})
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
@@ -19,13 +19,19 @@
 #include <rosidl_typesupport_connext_cpp/visibility_control.h>
 
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#ifdef __clang__
-# pragma clang diagnostic ignored "-Wdeprecated-register"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include "@(spec.base_type.pkg_name)/@(subfolder)/dds_connext/@(spec.base_type.type)_Support.h"
-#pragma GCC diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
 #include "@(spec.base_type.pkg_name)/@(subfolder)/dds_connext/@(get_header_filename_from_msg_name(spec.base_type.type))__type_support.hpp"
 #include "rosidl_typesupport_connext_cpp/identifier.hpp"
 #include "rosidl_typesupport_connext_cpp/message_type_support.h"
@@ -39,7 +45,7 @@ namespace msg
 {
 namespace dds_
 {
-struct @(field.type.type)_;
+class @(field.type.type)_;
 }  // namespace dds_
 namespace typesupport_connext_cpp
 {
@@ -195,7 +201,7 @@ convert_dds_message_to_ros(
     for (size_t i = 0; i < size; i++) {
 @[if field.type.is_primitive_type()]@
       ros_message.@(field.name)[i] =
-        dds_message.@(field.name)_[i];
+        dds_message.@(field.name)_[i]@(' == DDS_BOOLEAN_TRUE' if field.type.type == 'bool' else '');
 @[else]@
       if (
         !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_dds_message_to_ros(
@@ -209,7 +215,7 @@ convert_dds_message_to_ros(
   }
 @[elif field.type.is_primitive_type()]@
   ros_message.@(field.name) =
-    dds_message.@(field.name)_;
+    dds_message.@(field.name)_@(' == DDS_BOOLEAN_TRUE' if field.type.type == 'bool' else '');
 @[else]@
   if (
     !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_dds_message_to_ros(

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.template
@@ -12,6 +12,9 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
+#include <limits>
+#include <stdexcept>
+
 #include <rosidl_generator_c/message_type_support.h>
 // this is defined in the rosidl_typesupport_connext_cpp package and
 // is in the include/rosidl_typesupport_connext_cpp/impl folder
@@ -100,28 +103,32 @@ convert_ros_message_to_dds(
     size_t size = @(field.type.array_size);
 @[else]@
     size_t size = ros_message.@(field.name).size();
+    if (size > (std::numeric_limits<DDS_Long>::max)()) {
+      throw std::runtime_error("array size exceeds maximum DDS sequence size");
+    }
+    DDS_Long length = static_cast<DDS_Long>(size);
 @[if not field.type.is_upper_bound]@
-    if (!dds_message.@(field.name)_.maximum(size)) {
+    if (!dds_message.@(field.name)_.maximum(length)) {
       throw std::runtime_error("failed to set maximum of sequence");
     }
 @[end if]@
-    if (!dds_message.@(field.name)_.length(size)) {
+    if (!dds_message.@(field.name)_.length(length)) {
       throw std::runtime_error("failed to set length of sequence");
     }
 @[end if]@
     for (size_t i = 0; i < size; i++) {
 @[if field.type.type == 'string']@
-      DDS_String_free(dds_message.@(field.name)_[i]);
-      dds_message.@(field.name)_[i] =
+      DDS_String_free(dds_message.@(field.name)_[static_cast<DDS_Long>(i)]);
+      dds_message.@(field.name)_[static_cast<DDS_Long>(i)] =
         DDS_String_dup(ros_message.@(field.name)[i].c_str());
 @[elif field.type.is_primitive_type()]@
-      dds_message.@(field.name)_[i] =
+      dds_message.@(field.name)_[static_cast<DDS_Long>(i)] =
         ros_message.@(field.name)[i];
 @[else]@
       if (
         !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_ros_message_to_dds(
           ros_message.@(field.name)[i],
-          dds_message.@(field.name)_[i]))
+          dds_message.@(field.name)_[static_cast<DDS_Long>(i)]))
       {
         return false;
       }
@@ -201,11 +208,11 @@ convert_dds_message_to_ros(
     for (size_t i = 0; i < size; i++) {
 @[if field.type.is_primitive_type()]@
       ros_message.@(field.name)[i] =
-        dds_message.@(field.name)_[i]@(' == DDS_BOOLEAN_TRUE' if field.type.type == 'bool' else '');
+        dds_message.@(field.name)_[static_cast<DDS_Long>(i)]@(' == DDS_BOOLEAN_TRUE' if field.type.type == 'bool' else '');
 @[else]@
       if (
         !@(field.type.pkg_name)::msg::typesupport_connext_cpp::convert_dds_message_to_ros(
-          dds_message.@(field.name)_[i],
+          dds_message.@(field.name)_[static_cast<DDS_Long>(i)],
           ros_message.@(field.name)[i]))
       {
         return false;

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
@@ -9,15 +9,20 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#ifdef __clang__
-# pragma clang diagnostic ignored "-Wdeprecated-register"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include <ndds/connext_cpp/connext_cpp_requester_details.h>
 #include <ndds/ndds_cpp.h>
 #include <ndds/ndds_requestreply_cpp.h>
-#pragma GCC diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <rmw/rmw.h>
 // this is defined in the rosidl_typesupport_connext_cpp package and


### PR DESCRIPTION
* fix all warnings on OS X: http://ci.ros2.org/job/ros2_batch_ci_osx/34/
* fix 1.5k warnings on Windows: http://ci.ros2.org/job/ros2_batch_ci_windows/51/ 

The remaining Windows warnings are:
* either type conversion warnings
* or usage of deprecated functions (due to no upper limit for string processing)