### PR TITLE
check if rtiddsgen_server is runnable

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -33,7 +33,7 @@
 # - Connext_DEFINITIONS: Definitions to be passed on
 # - Connext_DDSGEN: Path to the idl2code generator
 # - Connext_DDSGEN_SERVER: Path to the idl2code generator in server mode
-#   (if available)
+#   (if available and runnable)
 #
 # Example usage:
 #
@@ -253,6 +253,16 @@ endif()
 
 if(Connext_FOUND AND NOT WIN32)
   list(APPEND Connext_LIBRARIES "pthread" "dl")
+endif()
+
+if(Connext_DDSGEN_SERVER)
+  # check that the generator is invocable / finds a Java runtime environment
+  execute_process(
+    COMMAND "/usr/bin/rtiddsgen_server"
+    RESULT_VARIABLE _retcode)
+  if(NOT _retcode EQUAL 0)
+    set(Connext_DDSGEN_SERVER)
+  endif()
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
If the Java program is not runnable (e.g. no Java runtime environment available) it does not set the variable (and therefore depending code falls back using the non-server generator.

Failed in http://ci.ros2.org/job/ros2_batch_ci_osx/129/
Worked in http://ci.ros2.org/job/ros2_batch_ci_osx/130/