### PR TITLE
set _CRT_NONSTDC_NO_DEPRECATE on Windows

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -37,7 +37,9 @@ configure_rmw_library(rmw_connext_cpp)
 # Additionally, on Windows, add the ROSIDL_TYPESUPPORT_CONNEXT_CPP_BUILDING_DLL definition.
 if(WIN32)
   target_compile_definitions(rmw_connext_cpp
-      PRIVATE "ROSIDL_TYPESUPPORT_CONNEXT_CPP_BUILDING_DLL")
+    PRIVATE "_CRT_NONSTDC_NO_DEPRECATE")
+  target_compile_definitions(rmw_connext_cpp
+    PRIVATE "ROSIDL_TYPESUPPORT_CONNEXT_CPP_BUILDING_DLL")
 endif()
 
 ament_export_libraries(rmw_connext_cpp "${Connext_LIBRARIES}")

--- a/rmw_connext_dynamic_cpp/CMakeLists.txt
+++ b/rmw_connext_dynamic_cpp/CMakeLists.txt
@@ -39,7 +39,9 @@ configure_rmw_library(rmw_connext_dynamic_cpp)
 # Additionally, on Windows, add the ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL definition.
 if(WIN32)
   target_compile_definitions(rmw_connext_dynamic_cpp
-      PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL")
+    PRIVATE "_CRT_NONSTDC_NO_DEPRECATE")
+  target_compile_definitions(rmw_connext_dynamic_cpp
+    PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL")
 endif()
 
 if(NOT WIN32)


### PR DESCRIPTION
Fixes 4 warnings: http://ci.ros2.org/job/ros2_batch_ci_windows/203/warnings34Result/fixed/

Connects to ros2/ros2#53