### PR TITLE
use Connext debug libraries when building with CMAKE_BUILD_TYPE Debug

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -66,11 +66,15 @@ function(_find_connext_ensure_libraries var expected_library_names library_paths
   set(${var} TRUE PARENT_SCOPE)
 endfunction()
 
+set(_lib_suffix "")
+if("${CMAKE_BUILD_TYPE} " STREQUAL "Debug ")
+  set(_lib_suffix "d")
+endif()
 set(_expected_library_base_names
-  "nddsc"
-  "nddscore"
-  "nddscpp"
-  "rticonnextmsgcpp"
+  "nddsc${_lib_suffix}"
+  "nddscore${_lib_suffix}"
+  "nddscpp${_lib_suffix}"
+  "rticonnextmsgcpp${_lib_suffix}"
 )
 
 set(_expected_library_names "")


### PR DESCRIPTION
Replacing #77 (following style). This is orthogonal to the use of the Community edition. It already works with the currently used professional version of Connext.

Since the CI jobs don't build with `CMAKE_BUILD_TYPE=Debug` there is no need to trigger jobs for this.