### PR TITLE
adding error handling to connext implementation publisher cleanup

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -436,7 +436,10 @@ rmw_destroy_node(rmw_node_t * node)
   }
   // This unregisters types and destroys topics which were shared between
   // publishers and subscribers and could not be cleaned up in the delete functions.
-  participant->delete_contained_entities();
+  if (participant->delete_contained_entities() != DDS::RETCODE_OK) {
+    RMW_SET_ERROR_MSG("failed to delete contained entities of participant");
+    return RMW_RET_ERROR;
+  }
 
   DDS_ReturnCode_t ret = dpf_->delete_participant(participant);
   if (ret != DDS_RETCODE_OK) {

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -414,8 +414,10 @@ rmw_destroy_node(rmw_node_t * node)
   }
   // This unregisters types and destroys topics which were shared between
   // publishers and subscribers and could not be cleaned up in the delete functions.
-  participant->delete_contained_entities();
-
+  if (participant->delete_contained_entities() != DDS::RETCODE_OK) {
+    RMW_SET_ERROR_MSG("failed to delete contained entities of participant");
+    return RMW_RET_ERROR;
+  }
   DDS_ReturnCode_t ret = dpf_->delete_participant(participant);
   if (ret != DDS_RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to delete participant");


### PR DESCRIPTION
This mirrors comments in ros2/rmw_opensplice#72

http://ci.ros2.org/job/ros2_batch_ci_linux/269/
http://ci.ros2.org/job/ros2_batch_ci_osx/189/
http://ci.ros2.org/job/ros2_batch_ci_windows/269/