### PR TITLE
Use transient QoS for the requester/replier data writers/readers

### DIFF
--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -97,6 +97,9 @@ bool set_entity_qos_from_profile(const rmw_qos_profile_t & qos_profile,
     case RMW_QOS_POLICY_TRANSIENT_LOCAL_DURABILITY:
       entity_qos.durability.kind = DDS_TRANSIENT_LOCAL_DURABILITY_QOS;
       break;
+    case RMW_QOS_POLICY_VOLATILE_DURABILITY:
+      entity_qos.durability.kind = DDS_VOLATILE_DURABILITY_QOS;
+      break;
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       break;
     default:

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -93,6 +93,17 @@ bool set_entity_qos_from_profile(const rmw_qos_profile_t & qos_profile,
       return false;
   }
 
+  switch (qos_profile.durability) {
+    case RMW_QOS_POLICY_TRANSIENT_LOCAL_DURABILITY:
+      entity_qos.durability.kind = DDS_TRANSIENT_LOCAL_DURABILITY_QOS;
+      break;
+    case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
+      break;
+    default:
+      RMW_SET_ERROR_MSG("Unknown QoS durability policy");
+      return false;
+  }
+
   if (qos_profile.depth != RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT) {
     entity_qos.history.depth = static_cast<DDS_Long>(qos_profile.depth);
   }


### PR DESCRIPTION
This PR adds the logic needed to apply the durability policy to data readers and writers.

Connects to ros2/rmw#41
