### PR TITLE
fix missing export of include directory

### DIFF
--- a/rmw_connext_shared_cpp/CMakeLists.txt
+++ b/rmw_connext_shared_cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(rmw REQUIRED)
 include_directories(include)
 
 ament_export_definitions(${Connext_DEFINITIONS})
-ament_export_include_directories(${Connext_INCLUDE_DIRS})
+ament_export_include_directories(include ${Connext_INCLUDE_DIRS})
 
 ament_export_dependencies(rmw)
 


### PR DESCRIPTION
Fix regression of #93.

Failing build: http://ci.ros2.org/job/ros2_batch_ci_linux/460/console#console-section-16
Succeeding build: http://ci.ros2.org/job/ros2_batch_ci_linux/464