### PR TITLE
Fix ddsgen server

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -235,7 +235,7 @@ endif()
 if(Connext_DDSGEN_SERVER)
   # check that the generator is invocable / finds a Java runtime environment
   execute_process(
-    COMMAND "/usr/bin/rtiddsgen_server"
+    COMMAND "${Connext_DDSGEN_SERVER}"
     RESULT_VARIABLE _retcode
     OUTPUT_QUIET ERROR_QUIET)
   if(NOT _retcode EQUAL 0)

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -153,7 +153,7 @@ add_custom_command(
   --dds-interface-base-path "${_dds_idl_base_path}"
   --idl-pp "${_idl_pp}"
   DEPENDS ${target_dependencies} ${_dds_idl_files}
-  COMMENT "Generating C++ type support for RTI Connext"
+  COMMENT "Generating C++ type support for RTI Connext (using '${_idl_pp}')"
   VERBATIM
 )
 


### PR DESCRIPTION
Doesn't have any effect on the farm where the tool is actually in /usr/bin so no CI job.