### PR TITLE
update connext environment generation

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -27,6 +27,7 @@
 # - Connext_FOUND: flag indicating if the package was found
 # - Connext_INCLUDE_DIRS: Paths to the header files
 # - Connext_HOME: Root directory for the NDDS install.
+# - Connext_ARCHITECTURE_NAME: Architecture name according to the lib subfolder
 # - Connext_LIBRARIES: Name to the C++ libraries including the path
 # - Connext_LIBRARY_DIRS: Paths to the libraries
 # - Connext_LIBRARY_DIR: Path to libraries; guaranteed to be a single path
@@ -184,6 +185,9 @@ if(NOT "${_NDDSHOME} " STREQUAL " ")
   # Since we know Connext_LIBRARY_DIRS is a single path, just alias it.
   set(Connext_LIBRARY_DIR "${Connext_LIBRARY_DIRS}")
 
+  # extract architecture name
+  get_filename_component(Connext_ARCHITECTURE_NAME "${Connext_LIBRARY_DIR}" NAME)
+
   if(WIN32)
     set(Connext_DEFINITIONS "RTI_WIN32" "NDDS_DLL_VARIABLE")
     # This will be a .bat file and it will be on the PATH.
@@ -244,7 +248,8 @@ if(Connext_DDSGEN_SERVER)
 endif()
 
 include(FindPackageHandleStandardArgs)
-# Connext_HOME, Connext_LIBRARY_DIRS, and Connext_LIBRARY_DIR are not always set, depending on the source of Connext.
+# Connext_HOME, Connext_ARCHITECTURE_NAME, Connext_LIBRARY_DIRS, and
+# Connext_LIBRARY_DIR are not always set, depending on the source of Connext.
 find_package_handle_standard_args(Connext
   FOUND_VAR Connext_FOUND
   REQUIRED_VARS

--- a/connext_cmake_module/env_hook/connext.bat.in
+++ b/connext_cmake_module/env_hook/connext.bat.in
@@ -1,37 +1,10 @@
-set "Connext_HOME=@Connext_HOME@"
+set "_Connext_HOME=@Connext_HOME@"
+
+:: warn about changing the Connext location
+if "%NDDSHOME%" NEQ "" if "%NDDSHOME%" NEQ "%_Connext_HOME%" (
+  echo "NDDSHOME changed from \"%NDDSHOME%\" to \"%_Connext_HOME%\"" 1>&2
+)
 
 :: Call RTI's env setup script, piping stdout to nul, since they have echo on.
-call "%Connext_HOME:/=\%\resource\scripts\rtisetenv_x64Win64VS2013.bat" 1> nul
-
-:: Add the Connext_LIBRARY_DIR to the Path so .dll's can be found at runtime.
-set "Connext_LIBRARY_DIR=@Connext_LIBRARY_DIR@"
-call:ament_prepend_unique_value PATH "%Connext_LIBRARY_DIR:/=\%"
-set "Connext_LIBRARY_DIR="
-
-goto:eof
-
-:: function to prepend non-duplicate values to environment variables
-:: using colons as separators and avoiding trailing separators
-:ament_prepend_unique_value
-  setlocal enabledelayedexpansion
-  :: arguments
-  set "_listname=%~1"
-  set "_value=%~2"
-  :: expand the list variable
-  set "_list=!%_listname%!"
-  :: check if the list contains the value
-  set "_is_duplicate="
-  if "%_list%" NEQ "" (
-    for %%a in ("%_list:;=";"%") do (
-      if "%%~a" == "%_value%" set "_is_duplicate=1"
-    )
-  )
-  :: if it is not a duplicate prepend it
-  if "%_is_duplicate%" == "" (
-    :: produces a trailing semicolon when the list empty, but that's ok
-    set "_list=%_value%;%_list%"
-  )
-  (endlocal
-    set "%~1=%_list%"
-  )
-goto:eof
+call "%_Connext_HOME:/=\%\resource\scripts\rtisetenv_@Connext_ARCHITECTURE_NAME@.bat" 1> nul
+set "_Connext_HOME="

--- a/connext_cmake_module/env_hook/connext.sh.in
+++ b/connext_cmake_module/env_hook/connext.sh.in
@@ -1,4 +1,11 @@
-export Connext_HOME="@Connext_HOME@"
+_Connext_HOME="@Connext_HOME@"
+_Connext_LIBRARY_DIR="@Connext_LIBRARY_DIR@"
+
+# warn about changing the Connext location
+if [ ! -z "$NDDSHOME" -a "$NDDSHOME" != "$_Connext_HOME" ]; then
+>&2 echo "NDDSHOME changed from \"$NDDSHOME\" to \"$_Connext_HOME\""
+fi
+export NDDSHOME="$_Connext_HOME"
 
 # detect if running on Darwin platform
 _UNAME=`uname -s`
@@ -8,11 +15,16 @@ if [ "$_UNAME" = "Darwin" ]; then
 fi
 unset _UNAME
 
-# Put this libary dir on the PATH and LD_LIBRARY_PATH for the rtiddsgen tool.
-ament_prepend_unique_value PATH "@Connext_LIBRARY_DIR@"
+ament_prepend_unique_value PATH "$_Connext_HOME/bin"
+
+# add the libary dir on the (DY)LD_LIBRARY_PATH for the rtiddsgen tool
+ament_prepend_unique_value PATH "$_Connext_LIBRARY_DIR"
 if [ $_IS_DARWIN -eq 0 ]; then
-  ament_prepend_unique_value LD_LIBRARY_PATH "@Connext_LIBRARY_DIR@"
+  ament_prepend_unique_value LD_LIBRARY_PATH "$_Connext_LIBRARY_DIR"
 else
-  ament_prepend_unique_value DYLD_LIBRARY_PATH "@Connext_LIBRARY_DIR@"
+  ament_prepend_unique_value DYLD_LIBRARY_PATH "$_Connext_LIBRARY_DIR"
 fi
 unset _IS_DARWIN
+
+unset _Connext_LIBRARY_DIR
+unset _Connext_HOME


### PR DESCRIPTION
With this patch it is sufficient to source the environment of the ament workspace which will implicitly set all variables necessary to use Connext. Before Connext still needed to be source explicitly (at least on non-Windows platforms).

On Linux the library dir doesn't need to be on the path anymore.

On Windows the environment hook sources the "right" batch file based on the architecture name.

In both cases it warns now if the NDDSHOME changes.

http://ci.ros2.org/job/ros2_batch_ci_linux/554/
http://ci.ros2.org/job/ros2_batch_ci_osx/422/
http://ci.ros2.org/job/ros2_batch_ci_windows/569/