### PR TITLE
add missing run dependency on rmw_connext_shared_cpp

### DIFF
--- a/rmw_connext_dynamic_cpp/package.xml
+++ b/rmw_connext_dynamic_cpp/package.xml
@@ -20,6 +20,8 @@
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
 
+  <exec_depend>rmw_connext_shared_cpp</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Same as https://github.com/ros2/rmw_connext/blob/43f847c3545d400fd995a1370579e951a3c930b1/rmw_connext_cpp/package.xml#L28