### PR TITLE
null not triggered conditions on timeout

### DIFF
--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -371,11 +371,7 @@ wait(const char * implementation_identifier,
   }
   DDS_ReturnCode_t status = dds_waitset->wait(*active_conditions, timeout);
 
-  if (status == DDS_RETCODE_TIMEOUT) {
-    return RMW_RET_TIMEOUT;
-  }
-
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS_RETCODE_OK && status != DDS_RETCODE_TIMEOUT) {
     RMW_SET_ERROR_MSG("failed to wait on waitset");
     return RMW_RET_ERROR;
   }
@@ -493,6 +489,10 @@ wait(const char * implementation_identifier,
     if (!(j < active_conditions->length())) {
       clients->clients[i] = 0;
     }
+  }
+
+  if (status == DDS_RETCODE_TIMEOUT) {
+    return RMW_RET_TIMEOUT;
   }
   return RMW_RET_OK;
 }


### PR DESCRIPTION
Otherwise `rclcpp` considers all conditions "active".

Based on what @gerkey discovered while looking into ros2/rclcpp#192.

http://ci.ros2.org/job/ci_linux/961/
http://ci.ros2.org/job/ci_osx/801/
Waiting for http://ci.ros2.org/job/ci_windows/1052/