### PR TITLE
Enable service typesupport for C

### DIFF
--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -56,7 +56,7 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_external_msg_files "${_dds_output_path}/${_parent_folder}/dds_connext/${_msg_name}_Support.cxx")
     list(APPEND _generated_msg_files "${_output_path}/msg/dds_connext_c/${_header_name}__type_support_c.cpp")
   elseif("${_extension} " STREQUAL ".srv ")
-    #list(APPEND _generated_srv_files "${_output_path}/srv/dds_connext_c/${_header_name}__type_support.cpp")
+    list(APPEND _generated_srv_files "${_output_path}/srv/dds_connext_c/${_header_name}__type_support_c.cpp")
   else()
     message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
   endif()
@@ -113,7 +113,7 @@ set(target_dependencies
   "${rosidl_typesupport_connext_c_BIN}"
   ${rosidl_typesupport_connext_c_GENERATOR_FILES}
   "${rosidl_typesupport_connext_c_TEMPLATE_DIR}/msg__type_support_c.cpp.template"
-  # "${rosidl_typesupport_connext_c_TEMPLATE_DIR}/srv__type_support_c.cpp.template"
+  "${rosidl_typesupport_connext_c_TEMPLATE_DIR}/srv__type_support_c.cpp.template"
   ${_dependency_files})
 foreach(dep ${target_dependencies})
   if(NOT EXISTS "${dep}")

--- a/rosidl_typesupport_connext_c/rosidl_typesupport_connext_c/__init__.py
+++ b/rosidl_typesupport_connext_c/rosidl_typesupport_connext_c/__init__.py
@@ -19,7 +19,7 @@ from rosidl_cmake import expand_template
 from rosidl_cmake import extract_message_types
 from rosidl_cmake import get_newest_modification_time
 from rosidl_parser import parse_message_file
-# from rosidl_parser import parse_service_file
+from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
 
 
@@ -29,15 +29,15 @@ def generate_typesupport_connext_c(args):
         os.path.join(template_dir, 'msg__type_support_c.cpp.template'): '%s__type_support_c.cpp',
     }
 
-    # mapping_srvs = {
-    #     os.path.join(template_dir, 'srv__type_support_c.cpp.template'): '%s__type_support_c.cpp',
-    # }
+    mapping_srvs = {
+        os.path.join(template_dir, 'srv__type_support_c.cpp.template'): '%s__type_support_c.cpp',
+    }
 
     for template_file in mapping_msgs.keys():
         assert os.path.exists(template_file), 'Could not find template: ' + template_file
 
-    # for template_file in mapping_srvs.keys():
-    #     assert os.path.exists(template_file), 'Could not find template: ' + template_file
+    for template_file in mapping_srvs.keys():
+        assert os.path.exists(template_file), 'Could not find template: ' + template_file
 
     pkg_name = args['package_name']
     known_msg_types = extract_message_types(
@@ -79,18 +79,18 @@ def generate_typesupport_connext_c(args):
                           .format(template_file, generated_file))
                     raise
 
-        # elif extension == '.srv':
-        #     spec = parse_service_file(pkg_name, idl_file)
-        #     validate_field_types(spec, known_msg_types)
-        #     for template_file, generated_filename in mapping_srvs.items():
-        #         generated_file = os.path.join(
-        #             args['output_dir'], 'srv', 'dds_connext_c', generated_filename %
-        #             convert_camel_case_to_lower_case_underscore(spec.srv_name))
+        elif extension == '.srv':
+            spec = parse_service_file(pkg_name, idl_file)
+            validate_field_types(spec, known_msg_types)
+            for template_file, generated_filename in mapping_srvs.items():
+                generated_file = os.path.join(
+                    args['output_dir'], 'srv', 'dds_connext_c', generated_filename %
+                    convert_camel_case_to_lower_case_underscore(spec.srv_name))
 
-        #         data = {'spec': spec}
-        #         data.update(functions)
-        #         expand_template(
-        #             template_file, data, generated_file,
-        #             minimum_timestamp=latest_target_timestamp)
+                data = {'spec': spec}
+                data.update(functions)
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
 
     return 0


### PR DESCRIPTION
I believe this will fix an issue @dirk-thomas found with compiling packages with only services.

Because the template file for C services typesupport is currently empty, services won't actually work yet.