### PR TITLE
C services

### DIFF
--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -2298,13 +2298,18 @@ rmw_create_client(
     return NULL;
   }
 
-  const void * untyped_request_members;
-  const void * untyped_response_members;
-
-  untyped_request_members =
+  const void * untyped_request_members =
     get_request_ptr(type_support->data, type_support->typesupport_identifier);
-  untyped_response_members = get_response_ptr(type_support->data,
+  if (!untyped_request_members) {
+    RMW_SET_ERROR_MSG("couldn't get request members");
+    return NULL;
+  }
+  const void * untyped_response_members = get_response_ptr(type_support->data,
       type_support->typesupport_identifier);
+  if (!untyped_response_members) {
+    RMW_SET_ERROR_MSG("couldn't get response members");
+    return NULL;
+  }
 
   std::string request_type_name = _create_type_name(untyped_request_members, "srv",
       type_support->typesupport_identifier);

--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -198,6 +198,7 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_connext_c
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_connext_cpp
 )
@@ -216,13 +217,19 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
 endforeach()
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "Connext"
-  "rosidl_typesupport_connext_c")
+  "rosidl_typesupport_connext_c"
+  "${PROJECT_NAME}__rosidl_typesupport_connext_cpp")
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
+  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
+  ${rosidl_generate_interfaces_TARGET}__rosidl_typesupport_connext_cpp)
 
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+)
+add_dependencies(
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_interfaces_TARGET}__rosidl_typesupport_connext_cpp
 )
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_connext_c/include/rosidl_typesupport_connext_c/impl/rosidl_generator_c/message_type_support.h
+++ b/rosidl_typesupport_connext_c/include/rosidl_typesupport_connext_c/impl/rosidl_generator_c/message_type_support.h
@@ -32,6 +32,9 @@
 #define ROSIDL_GET_MSG_TYPE_SUPPORT(PkgName, MsgName) \
   ROSIDL_GET_TYPE_SUPPORT(PkgName, msg, MsgName)
 
+#define ROSIDL_GET_SRV_TYPE_SUPPORT(PkgName, MsgName) \
+  ROSIDL_GET_TYPE_SUPPORT(PkgName, srv, MsgName)
+
 #define ROSIDL_GET_TYPE_SUPPORT(PkgName, MsgSubfolder, MsgName) \
   ROSIDL_GET_TYPE_SUPPORT_FUNCTION(PkgName, MsgSubfolder, MsgName)()
 

--- a/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.template
+++ b/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.template
@@ -1,0 +1,173 @@
+// generated from rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.template
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <srv>__type_support_c.cpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
+#endif
+#include <ndds/connext_cpp/connext_cpp_requester_details.h>
+#include <ndds/ndds_cpp.h>
+#include <ndds/ndds_requestreply_cpp.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+#include <rmw/rmw.h>
+#include <rmw/error_handling.h>
+#include <rosidl_generator_cpp/service_type_support.hpp>
+// this is defined in the rosidl_typesupport_connext_cpp package and
+// is in the include/rosidl_typesupport_connext_cpp/impl folder
+#include <rosidl_generator_c/message_type_support.h>
+#include <rosidl_typesupport_connext_c/identifier.h>
+#include <rosidl_typesupport_connext_c/visibility_control.h>
+// Provides the definition of the service_type_support_callbacks_t struct.
+#include <rosidl_typesupport_connext_cpp/service_type_support.h>
+
+#include "@(spec.pkg_name)/srv/dds_connext/@(spec.srv_name)_Request_Support.h"
+#include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__type_support.hpp"
+#include "@(spec.pkg_name)/srv/dds_connext/@(spec.srv_name)_Response_Support.h"
+#include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name + '_Response'))__type_support.hpp"
+
+// Re-use most of the functions from C++ typesupport
+#include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name))__type_support.hpp"
+
+#include "@(spec.pkg_name)/msg/rosidl_generator_c__visibility_control.h"
+
+class DDSDomainParticipant;
+class DDSDataReader;
+struct DDS_SampleIdentity_t;
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+void * create_requester__@(spec.srv_name)(
+  void * untyped_participant,
+  const char * service_name,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
+  void ** untyped_reader,
+  void * (*allocator)(size_t))
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::create_requester__@(spec.srv_name)(
+    untyped_participant,
+    service_name,
+    untyped_datareader_qos,
+    untyped_datawriter_qos,
+    untyped_reader,
+    allocator);
+}
+const char * destroy_requester__@(spec.srv_name)(
+  void * untyped_requester,
+  void (* deallocator)(void *))
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::destroy_requester__@(spec.srv_name)(
+    untyped_requester, deallocator);
+}
+
+int64_t send_request__@(spec.srv_name)(
+  void * untyped_requester,
+  const void * untyped_ros_request)
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::send_request__@(spec.srv_name)(
+    untyped_requester, untyped_ros_request);
+}
+
+void * create_replier__@(spec.srv_name)(
+  void * untyped_participant,
+  const char * service_name,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
+  void ** untyped_reader,
+  void * (*allocator)(size_t))
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::create_replier__@(spec.srv_name)(
+    untyped_participant,
+    service_name,
+    untyped_datareader_qos,
+    untyped_datawriter_qos,
+    untyped_reader,
+    allocator);
+}
+
+const char * destroy_replier__@(spec.srv_name)(
+  void * untyped_replier,
+  void (* deallocator)(void *))
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::destroy_replier__@(spec.srv_name)(
+    untyped_replier, deallocator);
+}
+
+bool take_request__@(spec.srv_name)(
+  void * untyped_replier,
+  rmw_request_id_t * request_header,
+  void * untyped_ros_request)
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::take_request__@(spec.srv_name)(
+    untyped_replier, request_header, untyped_ros_request);
+}
+
+bool take_response__@(spec.srv_name)(
+  void * untyped_requester,
+  rmw_request_id_t * request_header,
+  void * untyped_ros_response)
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::take_request__@(spec.srv_name)(
+    untyped_requester, request_header, untyped_ros_response);
+}
+
+bool send_response__@(spec.srv_name)(
+  void * untyped_replier,
+  const rmw_request_id_t * request_header,
+  const void * untyped_ros_response)
+{
+  return @(spec.pkg_name)::srv::typesupport_connext_cpp::send_response__@(spec.srv_name)(
+    untyped_replier, request_header, untyped_ros_response);
+}
+
+static service_type_support_callbacks_t __callbacks = {
+  "@(spec.pkg_name)",
+  "@(spec.srv_name)",
+  &create_requester__@(spec.srv_name),
+  &destroy_requester__@(spec.srv_name),
+  &create_replier__@(spec.srv_name),
+  &destroy_replier__@(spec.srv_name),
+  &send_request__@(spec.srv_name),
+  &take_request__@(spec.srv_name),
+  &send_response__@(spec.srv_name),
+  &take_response__@(spec.srv_name),
+};
+
+static rosidl_service_type_support_t __type_support = {
+  rosidl_typesupport_connext_c__identifier,
+  &__callbacks
+};
+
+
+ROSIDL_GENERATOR_C_EXPORT_@(spec.pkg_name)
+const rosidl_service_type_support_t *
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name))()
+{
+  if (!__type_support.typesupport_identifier) {
+    __type_support.typesupport_identifier = rosidl_typesupport_connext_c__identifier;
+  }
+  return &__type_support;
+}
+
+#if defined(__cplusplus)
+}
+#endif

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -62,6 +62,7 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_msg_files "${_output_path}/${_parent_folder}/dds_connext/${_header_name}__type_support.cpp")
   elseif("${_extension} " STREQUAL ".srv ")
     list(APPEND _generated_srv_files "${_output_path}/srv/dds_connext/${_header_name}__type_support.cpp")
+    list(APPEND _generated_srv_files "${_output_path}/srv/dds_connext/${_header_name}__type_support.hpp")
   else()
     message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
   endif()
@@ -121,6 +122,7 @@ set(target_dependencies
   ${rosidl_typesupport_connext_cpp_GENERATOR_FILES}
   "${rosidl_typesupport_connext_cpp_TEMPLATE_DIR}/msg__type_support.hpp.template"
   "${rosidl_typesupport_connext_cpp_TEMPLATE_DIR}/msg__type_support.cpp.template"
+  "${rosidl_typesupport_connext_cpp_TEMPLATE_DIR}/srv__type_support.hpp.template"
   "${rosidl_typesupport_connext_cpp_TEMPLATE_DIR}/srv__type_support.cpp.template"
   ${_dependency_files})
 foreach(dep ${target_dependencies})

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/service_type_support.h
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/service_type_support.h
@@ -16,7 +16,7 @@
 #define ROSIDL_TYPESUPPORT_CONNEXT_CPP__SERVICE_TYPE_SUPPORT_H_
 
 #include <stdint.h>
-
+#include <rmw/types.h>
 #include "rosidl_generator_c/service_type_support.h"
 
 typedef struct service_type_support_callbacks_t

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
@@ -1,4 +1,5 @@
 // generated from rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+// generated code does not contain a copyright notice
 
 @#######################################################################
 @# EmPy template for generating <srv>__type_support.cpp files
@@ -24,7 +25,6 @@
 # pragma GCC diagnostic pop
 #endif
 
-#include <rmw/rmw.h>
 #include <rmw/error_handling.h>
 // this is defined in the rosidl_typesupport_connext_cpp package and
 // is in the include/rosidl_typesupport_connext_cpp/impl folder
@@ -33,6 +33,7 @@
 #include "rosidl_typesupport_connext_cpp/service_type_support.h"
 #include <rosidl_typesupport_connext_cpp/visibility_control.h>
 
+#include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name))__type_support.hpp"
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
 #include "@(spec.pkg_name)/srv/dds_connext/@(spec.srv_name)_Request_Support.h"
 #include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name + '_Request'))__type_support.hpp"

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.hpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.hpp.template
@@ -1,0 +1,92 @@
+// generated from rosidl_typesupport_connext_cpp/resource/srv__type_support.hpp.template
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <srv>__type_support.hpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_srv_name (function)
+@#######################################################################
+@
+#ifndef __@(spec.pkg_name)__srv__dds_connext__@(get_header_filename_from_msg_name(spec.srv_name))__type_support__hpp__
+#define __@(spec.pkg_name)__srv__dds_connext__@(get_header_filename_from_msg_name(spec.srv_name))__type_support__hpp__
+
+#include <rosidl_typesupport_connext_cpp/visibility_control.h>
+
+#include <rmw/types.h>
+
+namespace @(spec.pkg_name)
+{
+
+namespace srv
+{
+
+namespace typesupport_connext_cpp
+{
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+void *
+create_requester__@(spec.srv_name)(
+  void * untyped_participant,
+  const char * service_name,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
+  void ** untyped_reader,
+  void * (*allocator)(size_t));
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+const char *
+destroy_requester__@(spec.srv_name)(
+  void * untyped_requester,
+  void (* deallocator)(void *));
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+int64_t
+send_request__@(spec.srv_name)(
+  void * untyped_requester,
+  const void * untyped_ros_request);
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+void *
+create_replier__@(spec.srv_name)(
+  void * untyped_participant,
+  const char * service_name,
+  const void * untyped_datareader_qos,
+  const void * untyped_datawriter_qos,
+  void ** untyped_reader,
+  void * (*allocator)(size_t));
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+const char *
+destroy_replier__@(spec.srv_name)(
+  void * untyped_replier,
+  void (* deallocator)(void *));
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+bool
+take_request__@(spec.srv_name)(
+  void * untyped_replier,
+  rmw_request_id_t * request_header,
+  void * untyped_ros_request);
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+bool
+take_response__@(spec.srv_name)(
+  void * untyped_requester,
+  rmw_request_id_t * request_header,
+  void * untyped_ros_response);
+
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+bool
+send_response__@(spec.srv_name)(
+  void * untyped_replier,
+  const rmw_request_id_t * request_header,
+  const void * untyped_ros_response);
+}  // namespace typesupport_connext_cpp
+
+}  // namespace srv
+
+}  // namespace @(spec.pkg_name)
+
+#endif  // __@(spec.pkg_name)__srv__dds_connext__@(get_header_filename_from_msg_name(spec.srv_name))__type_support__hpp__

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
@@ -204,6 +204,8 @@ def generate_cpp(args, message_specs, service_specs, known_msg_types):
     mapping_srvs = {
         os.path.join(template_dir, 'srv__type_support.cpp.template'):
         '%s__type_support.cpp',
+        os.path.join(template_dir, 'srv__type_support.hpp.template'):
+        '%s__type_support.hpp',
     }
 
     for template_file in mapping_msgs.keys():


### PR DESCRIPTION
Connects to ros2/rcl#27
based on #140

Yet another C services pull request.

Provide a generated library that creates the expected C structures for service-related callbacks and calls directly to the C++ implementation.

Again it's a bit strange that C type support depends so much on C++ type support. Perhaps we should reverse the dependency so that C++ depends on C. Regardless, I think that the principal of it is fairly sound to reduce code duplication.