### PR TITLE
suppress warning for generated Connext code

### DIFF
--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -77,6 +77,7 @@ if(NOT WIN32)
     )
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(_connext_compile_flags
+      "-Wno-strict-aliasing"
       "-Wno-unused-but-set-variable"
       "-Wno-unused-parameter"
       "-Wno-unused-variable")

--- a/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.template
+++ b/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.template
@@ -38,6 +38,7 @@ static_assert(USING_ROSIDL_TYPESUPPORT_CONNEXT_C, "expected Connext C message ty
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wunused-variable"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"


### PR DESCRIPTION
This will fix the following compiler warnings: http://ci.ros2.org/job/ci_linux/1051/warnings17Result/category.-2074711528/