### PR TITLE
Change semantics of how rmw arrays are interpreted

### DIFF
--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -279,11 +279,15 @@ wait(const char * implementation_identifier,
   }
 
   // add a condition for each subscriber
-  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count && subscriptions->subscribers; ++i) {
+    // A null entry indicates the end of the subscriptions array.
+    if (!subscriptions->subscribers[i]) {
+      break;
+    }
     SubscriberInfo * subscriber_info =
       static_cast<SubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {
-      RMW_SET_ERROR_MSG("subscriber info handle is null");
+      RMW_SET_ERROR_MSG("Invalid cast to a Connext SubscriberInfo struct");
       return RMW_RET_ERROR;
     }
     DDSReadCondition * read_condition = subscriber_info->read_condition_;
@@ -299,12 +303,15 @@ wait(const char * implementation_identifier,
   }
 
   // add a condition for each guard condition
-  if (guard_conditions) {
+  if (guard_conditions && guard_conditions->guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
+      if (!guard_conditions->guard_conditions[i]) {
+        break;
+      }
       DDSGuardCondition * guard_condition =
         static_cast<DDSGuardCondition *>(guard_conditions->guard_conditions[i]);
       if (!guard_condition) {
-        RMW_SET_ERROR_MSG("guard condition handle is null");
+        RMW_SET_ERROR_MSG("Invalid cast to a Connext DDSGuardCondition struct");
         return RMW_RET_ERROR;
       }
       rmw_ret_t rmw_status = check_attach_condition_error(
@@ -316,11 +323,14 @@ wait(const char * implementation_identifier,
   }
 
   // add a condition for each service
-  for (size_t i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count && services->services; ++i) {
+    if (!services->services[i]) {
+      break;
+    }
     ServiceInfo * service_info =
       static_cast<ServiceInfo *>(services->services[i]);
     if (!service_info) {
-      RMW_SET_ERROR_MSG("service info handle is null");
+      RMW_SET_ERROR_MSG("Invalid cast to Connext ServiceInfo struct");
       return RMW_RET_ERROR;
     }
     DDSReadCondition * read_condition = service_info->read_condition_;
@@ -336,7 +346,10 @@ wait(const char * implementation_identifier,
   }
 
   // add a condition for each client
-  for (size_t i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count && clients->clients; ++i) {
+    if (!clients->clients[i]) {
+      break;
+    }
     ClientInfo * client_info =
       static_cast<ClientInfo *>(clients->clients[i]);
     if (!client_info) {
@@ -377,7 +390,10 @@ wait(const char * implementation_identifier,
   }
 
   // set subscriber handles to zero for all not triggered conditions
-  for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
+  for (size_t i = 0; i < subscriptions->subscriber_count && subscriptions->subscribers; ++i) {
+    if (!subscriptions->subscribers[i]) {
+      break;
+    }
     SubscriberInfo * subscriber_info =
       static_cast<SubscriberInfo *>(subscriptions->subscribers[i]);
     if (!subscriber_info) {
@@ -405,8 +421,11 @@ wait(const char * implementation_identifier,
   }
 
   // set guard condition handles to zero for all not triggered conditions
-  if (guard_conditions) {
+  if (guard_conditions && guard_conditions->guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
+      if (!guard_conditions->guard_conditions[i]) {
+        break;
+      }
       DDSCondition * condition =
         static_cast<DDSCondition *>(guard_conditions->guard_conditions[i]);
       if (!condition) {
@@ -436,7 +455,10 @@ wait(const char * implementation_identifier,
   }
 
   // set service handles to zero for all not triggered conditions
-  for (size_t i = 0; i < services->service_count; ++i) {
+  for (size_t i = 0; i < services->service_count && services->services; ++i) {
+    if (!services->services[i]) {
+      break;
+    }
     ServiceInfo * service_info =
       static_cast<ServiceInfo *>(services->services[i]);
     if (!service_info) {
@@ -464,7 +486,10 @@ wait(const char * implementation_identifier,
   }
 
   // set client handles to zero for all not triggered conditions
-  for (size_t i = 0; i < clients->client_count; ++i) {
+  for (size_t i = 0; i < clients->client_count && clients->clients; ++i) {
+    if (!clients->clients[i]) {
+      break;
+    }
     ClientInfo * client_info =
       static_cast<ClientInfo *>(clients->clients[i]);
     if (!client_info) {


### PR DESCRIPTION
I discussed with @wjwwood online after running into some issues integrating rcl and rclcpp and we decided that the rmw implementations need to interpret the arrays of subscriptions, guard conditions, and clients are interpreted, to match how rcl allocates and fills the rmw arrays that it passes to `rmw_wait`. Instead of treating the `..._count` field as the number of valid entries in the array, `rmw_wait` now treats the `count` as the capacity of the array, and stops iterating over the entries of the array when a null entry is encountered.