### PR TITLE
Make identifier consistent with package name

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -64,7 +64,7 @@ _create_type_name(
 
 extern "C"
 {
-const char * rti_connext_identifier = "connext_static";
+const char * rti_connext_identifier = "rmw_connext_cpp";
 
 
 struct ConnextStaticPublisherInfo

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -172,7 +172,7 @@ const void * get_response_ptr(const void * untyped_service_members, const char *
 extern "C"
 {
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
-const char * rti_connext_dynamic_identifier = "connext_dynamic";
+const char * rti_connext_dynamic_identifier = "rmw_connext_dynamic_cpp";
 
 struct CustomPublisherInfo
 {


### PR DESCRIPTION
Make the hardcoded string identifier consistent with the package name. This is to avoid a hardcoded map in any situation where we want to match the identifier to the rmw implementation package name, e.g. https://github.com/ros2/rosidl/blob/master/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py#L17-L20

Perhaps the most proper thing to do would be to register an ament index entry to be used as the identifier (I discussed this with @wjwwood a while ago). This is a simpler fix for now (and avoids introducing a dependency on the ament index and introducing file IO).