### PR TITLE
fix memory leak

### DIFF
--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -506,6 +506,7 @@ destroy_guard_condition(const char * implementation_identifier,
   RMW_TRY_DESTRUCTOR(
     static_cast<DDSGuardCondition *>(guard_condition->data)->~DDSGuardCondition(),
     DDSGuardCondition, result = RMW_RET_ERROR)
+  rmw_free(guard_condition->data);
   rmw_guard_condition_free(guard_condition);
   return result;
 }


### PR DESCRIPTION
This was driving me insane. Any example of rclcpp or rcl leaks memory from the guard condition handles (you can check with `valgrind --leak-check=full -v <executable name>`). This fixes the leaks.