### PR TITLE
ignore warning with Clang in Connext code

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -29,6 +29,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -32,6 +32,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -29,6 +29,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
@@ -31,6 +31,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif

--- a/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.template
+++ b/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.template
@@ -16,6 +16,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.template
@@ -17,6 +17,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Winfinite-recursion"
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif


### PR DESCRIPTION
Before: http://ci.ros2.org/job/ci_osx/1010/

After: http://ci.ros2.org/job/ci_osx/1014/