### PR TITLE
Fix null terminator

### DIFF
--- a/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.template
+++ b/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.template
@@ -196,7 +196,7 @@ convert_ros_to_dds(const void * untyped_ros_message, void * untyped_dds_message)
         fprintf(stderr, "string capacity not greater than size\n");
         return false;
       }
-      if (str->data[str->size - 1] == '\0') {
+      if (str->data[str->size] != '\0') {
         fprintf(stderr, "string not null-terminated\n");
         return false;
       }
@@ -219,7 +219,7 @@ convert_ros_to_dds(const void * untyped_ros_message, void * untyped_dds_message)
       fprintf(stderr, "string capacity not greater than size\n");
       return false;
     }
-    if (str->data[str->size - 1] == '\0') {
+    if (str->data[str->size] != '\0') {
       fprintf(stderr, "string not null-terminated\n");
       return false;
     }


### PR DESCRIPTION
This fixes the null terminator character check in strings

Relies on https://github.com/ros2/rmw_connext/pull/154
Connects to https://github.com/ros2/rclpy/issues/17