### PR TITLE
export --no-as-needed link flag

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -32,6 +32,7 @@
 # - Connext_LIBRARY_DIRS: Paths to the libraries
 # - Connext_LIBRARY_DIR: Path to libraries; guaranteed to be a single path
 # - Connext_DEFINITIONS: Definitions to be passed on
+# - Connext_LINK_FLAGS: Definitions to be passed on
 # - Connext_DDSGEN: Path to the idl2code generator
 # - Connext_DDSGEN_SERVER: Path to the idl2code generator in server mode
 #   (if available and runnable)
@@ -299,12 +300,15 @@ else()
   endif()
 endif()
 
+set(Connext_LINK_FLAGS "")
 if(Connext_FOUND)
   if(NOT WIN32)
     list(APPEND Connext_LIBRARIES "pthread" "dl")
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND Connext_LINK_FLAGS "-Wl,--no-as-needed")
+
     # check with which ABI the Connext libraries are built
     configure_file(
       "${connext_cmake_module_DIR}/check_abi.cmake"

--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -62,6 +62,7 @@ ament_target_dependencies(rmw_connext_cpp
   "rosidl_typesupport_connext_cpp"
   "Connext")
 ament_export_libraries(rmw_connext_cpp ${Connext_LIBRARIES})
+ament_export_link_flags(${Connext_LINK_FLAGS})
 
 # On Windows this adds the RMW_BUILDING_DLL definition.
 # On Unix (GCC or Clang) it hides the symbols with -fvisibility=hidden.

--- a/rmw_connext_dynamic_cpp/CMakeLists.txt
+++ b/rmw_connext_dynamic_cpp/CMakeLists.txt
@@ -60,6 +60,7 @@ if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
     PRIVATE Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
 endif()
 ament_export_libraries(rmw_connext_dynamic_cpp ${Connext_LIBRARIES})
+ament_export_link_flags(${Connext_LINK_FLAGS})
 
 # On Windows this adds the RMW_BUILDING_DLL definition.
 # On Unix (GCC or Clang) it hides the symbols by default with -fvisibility=hidden.

--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -263,6 +263,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   )
 
   ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${Connext_LIBRARIES})
+  ament_export_link_flags(${Connext_LINK_FLAGS})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -265,6 +265,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   )
 
   ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} ${Connext_LIBRARIES})
+  ament_export_link_flags(${Connext_LINK_FLAGS})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)


### PR DESCRIPTION
Export the linker flags for the Connext packages to address https://github.com/ros2/rcl/pull/55#issuecomment-224669618 (as documented in the [Connext Platform notes](https://community.rti.com/static/documentation/connext-dds/5.2.3/doc/manuals/connext_dds/RTI_ConnextDDS_CoreLibraries_PlatformNotes.pdf)).

http://ci.ros2.org/job/ci_linux/1419/