### PR TITLE
flag to switch between ABI versions of libstdc++

### DIFF
--- a/connext_cmake_module/CMakeLists.txt
+++ b/connext_cmake_module/CMakeLists.txt
@@ -4,6 +4,7 @@ project(connext_cmake_module)
 
 find_package(ament_cmake REQUIRED)
 
+set(${PROJECT_NAME}_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 find_package(Connext MODULE)
 if(Connext_HOME)

--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -299,8 +299,27 @@ else()
   endif()
 endif()
 
-if(Connext_FOUND AND NOT WIN32)
-  list(APPEND Connext_LIBRARIES "pthread" "dl")
+if(Connext_FOUND)
+  if(NOT WIN32)
+    list(APPEND Connext_LIBRARIES "pthread" "dl")
+  endif()
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # check with which ABI the Connext libraries are built
+    configure_file(
+      "${connext_cmake_module_DIR}/check_abi.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi/CMakeLists.txt"
+      @ONLY
+    )
+    try_compile(
+      Connext_GLIBCXX_USE_CXX11_ABI_ZERO
+      "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi/build"
+      "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi"
+      check_abi exe)
+    if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+      message(STATUS "Connext was build with an old libc++ ABI and needs _GLIBCXX_USE_CXX11_ABI 0")
+    endif()
+  endif()
 endif()
 
 if(Connext_DDSGEN_SERVER)

--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -1,0 +1,23 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 2.8.3)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+
+add_definitions(@Connext_DEFINITIONS@)
+include_directories(@Connext_INCLUDE_DIRS@)
+add_executable(exe
+  "@connext_cmake_module_DIR@/check_abi.cpp")
+target_link_libraries(exe @Connext_LIBRARIES@)

--- a/connext_cmake_module/cmake/check_abi.cpp
+++ b/connext_cmake_module/cmake/check_abi.cpp
@@ -1,0 +1,35 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define _GLIBCXX_USE_CXX11_ABI 0
+
+#include <ndds/connext_cpp/connext_cpp_requester_details.h>
+
+#pragma GCC diagnostic ignored "-Wuninitialized"
+
+int main(int, char **)
+{
+  DDSDomainParticipantFactory * dpf = DDSDomainParticipantFactory::get_instance();
+
+  DDS_DomainParticipantQos qos;
+  dpf->get_default_participant_qos(qos);
+
+  DDS_DomainId_t domain = static_cast<DDS_DomainId_t>(1);
+
+  DDSDomainParticipant * p = dpf->create_participant(
+    domain, qos, NULL, DDS_STATUS_MASK_NONE);
+
+  connext::RequesterParams params(p);
+  params.service_name("foo");
+}

--- a/rmw_connext_dynamic_cpp/CMakeLists.txt
+++ b/rmw_connext_dynamic_cpp/CMakeLists.txt
@@ -55,6 +55,10 @@ ament_target_dependencies(rmw_connext_dynamic_cpp
   "rmw_connext_shared_cpp"
   "rosidl_generator_cpp"
   "Connext")
+if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+  target_compile_definitions(rmw_connext_dynamic_cpp
+    PRIVATE Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+endif()
 ament_export_libraries(rmw_connext_dynamic_cpp ${Connext_LIBRARIES})
 
 # On Windows this adds the RMW_BUILDING_DLL definition.

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef Connext_GLIBCXX_USE_CXX11_ABI_ZERO
 #define _GLIBCXX_USE_CXX11_ABI 0
+#endif
 
 #include <cassert>
 #include <exception>

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -170,6 +170,10 @@ endif()
 link_directories(${Connext_LIBRARY_DIRS})
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
   ${_generated_msg_files} ${_generated_external_msg_files} ${_generated_srv_files})
+if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+endif()
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix} "rmw")
 if(WIN32)
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
@@ -12,7 +12,10 @@
 @
 #include "@(spec.pkg_name)/srv/dds_connext/@(get_header_filename_from_msg_name(spec.srv_name))__type_support.hpp"
 
+#ifdef Connext_GLIBCXX_USE_CXX11_ABI_ZERO
 #define _GLIBCXX_USE_CXX11_ABI 0
+#endif
+
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
The binary packages provided by RTI atm are not using the C++11 ABI but the old ABI (see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html). So for building libraries on top of e.g. `connext_cpp_requester_details` the following must be set (as before): `#define _GLIBCXX_USE_CXX11_ABI 0`. The same is the case for the 5.2.0 Debian package created on Trusty.

In that case `connext_cmake_module` is exporting `Connext_GLIBCXX_USE_CXX11_ABI_ZERO` which will result in `#define _GLIBCXX_USE_CXX11_ABI 0` to be used (same as before: http://ci.ros2.org/job/ci_linux/1449/ (I already addressed the missing copyright))

But in the case of the newly build Connext 5.2.3 package (on Xenial with G++ 5.2.3) the define must not be set (we don't have CI to test this).