### PR TITLE
use target_compile_definitions instead of add_definitions for try compile

### DIFF
--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -16,8 +16,8 @@ cmake_minimum_required(VERSION 2.8.3)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 
-add_definitions(@Connext_DEFINITIONS@)
 include_directories(@Connext_INCLUDE_DIRS@)
 add_executable(exe
   "@connext_cmake_module_DIR@/check_abi.cpp")
+target_compile_definitions(exe PRIVATE @Connext_DEFINITIONS@)
 target_link_libraries(exe @Connext_LIBRARIES@)


### PR DESCRIPTION
Connect to ros2/rcl#66.

http://ci.ros2.org/job/ci_linux/1506/