### PR TITLE
Use --no-as-needed in abi check

### DIFF
--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 2.8.3)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wl,--no-as-needed")
 
 include_directories(@Connext_INCLUDE_DIRS@)
 add_executable(exe


### PR DESCRIPTION
can be changed to `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} @Connext_LINK_FLAGS@")` after https://github.com/ros2/rmw_connext/pull/173 is merged

connects to https://github.com/ros2/rcl/issues/66