### PR TITLE
update compiler check to match AppleClang

### DIFF
--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -66,7 +66,7 @@ endforeach()
 # If not on Windows, disable some warnings with Connext's generated code
 if(NOT WIN32)
   set(_connext_compile_flags)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(_connext_compile_flags
       "-Wno-deprecated-register"
       "-Wno-mismatched-tags"

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -71,7 +71,7 @@ endforeach()
 # If not on Windows, disable some warnings with Connext's generated code
 if(NOT WIN32)
   set(_connext_compile_flags)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(_connext_compile_flags
       "-Wno-deprecated-register"
       "-Wno-mismatched-tags"


### PR DESCRIPTION
With using CMake 3.5 and https://cmake.org/cmake/help/v3.0/policy/CMP0025.html we need to match `AppleClang`.

http://ci.ros2.org/job/ci_osx/1176/