### PR TITLE
fix string comparison since variable might not be defined

### DIFF
--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -145,7 +145,7 @@ rosidl_write_generator_arguments(
 )
 
 set(_idl_pp "${Connext_DDSGEN}")
-if(NOT Connext_DDSGEN_SERVER STREQUAL "")
+if(NOT "${Connext_DDSGEN_SERVER}" STREQUAL "")
   # use the code generator in server mode when available
   # because it speeds up the code generation step significantly
   set(_idl_pp "${Connext_DDSGEN_SERVER}")


### PR DESCRIPTION
Regression of #176.

Since the variable might not be defined the comparison needs to explicitly evaluate the variable.