### PR TITLE
enable async publish mode for publishers

### DIFF
--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -220,6 +220,8 @@ get_datawriter_qos(
     return false;
   }
 
+  // TODO(wjwwood): conditionally use the async publish mode using a heuristic:
+  //  https://github.com/ros2/rmw_connext/issues/190
   datawriter_qos.publish_mode.kind = DDS::ASYNCHRONOUS_PUBLISH_MODE_QOS;
 
   return true;

--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -220,6 +220,8 @@ get_datawriter_qos(
     return false;
   }
 
+  datawriter_qos.publish_mode.kind = DDS::ASYNCHRONOUS_PUBLISH_MODE_QOS;
+
   return true;
 }
 


### PR DESCRIPTION
Fixes https://github.com/ros2/rmw_connext/issues/181

I'd like feedback on whether or not we should always turn this on. I'm guessing there is a performance impact for turning it on, and so it may not be wise to do so. As I see it, we have a few options:

- turn it on always (this pr)
- expose an option for our users, throw an exception when the data is too large and the option is off (connext's behavior)
- use a heuristic to determine when to turn it on, but default to off

The last option is clearly attractive since it "just works" and would save performance when it could, but I see two problems with the approach: figuring out a heuristic that always works for Connext and differences in behavior when this is enabled vs disabled. It would be surprising for the publish function to change behavior depending on the message you're using.

Also, I'm pretty sure you cannot change this setting after creating the publisher, so we'll have to have a heuristic that can determine whether or not to turn it on before starting to publish data.

My first guess would be something like, turn on async publishing:

- If reliable and
  - if message has any unbounded fields (potentially infinite size) or
  - if message has all bounded fields, but the fixed max size is too big (whatever Connext's cut off is)

The problem being that this would mean we have to turn on async publishing for pretty much all of our messages, since many have unbounded strings.

For now, we can just turn it on always and I can ticket the need to figure out when to turn it off for performance gains.