### PR TITLE
use correct ABI for C typesupport if not C++11

### DIFF
--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -156,6 +156,10 @@ link_directories(${Connext_LIBRARY_DIRS})
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
   ${_generated_msg_files} ${_generated_external_msg_files} ${_generated_srv_files}
   ${_generated_external_srv_files})
+if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+endif()
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "rmw"
   "rosidl_typesupport_connext_cpp"

--- a/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
@@ -10,6 +10,10 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
+#ifdef Connext_GLIBCXX_USE_CXX11_ABI_ZERO
+#define _GLIBCXX_USE_CXX11_ABI 0
+#endif
+
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
This is the same logic as for the C++ type support. That makes it compile for me against the RTI binary again.