### PR TITLE
More detailed error message in RMW_CONNEXT_CHECK_TYPESUPPORT_IDENTIFIER

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -60,7 +60,18 @@
     rosidl_typesupport_connext_cpp::typesupport_connext_identifier && \
     TYPESUPPORT->typesupport_identifier != rosidl_typesupport_connext_c__identifier) \
   { \
-    RMW_SET_ERROR_MSG("type support identifier did not match valid typesupports"); \
+    char __msg[1024]; \
+    snprintf( \
+      __msg, 1024, \
+      "type support handle implementation '%s' (%p) does not match valid type supports " \
+      "('%s' (%p), '%s' (%p))", \
+      TYPESUPPORT->typesupport_identifier, \
+      TYPESUPPORT->typesupport_identifier, \
+      rosidl_typesupport_connext_cpp::typesupport_connext_identifier, \
+      rosidl_typesupport_connext_cpp::typesupport_connext_identifier, \
+      rosidl_typesupport_connext_c__identifier, \
+      rosidl_typesupport_connext_c__identifier); \
+    RMW_SET_ERROR_MSG(__msg); \
     return NULL; \
   }
 


### PR DESCRIPTION
this is to be more consistent with https://github.com/ros2/rmw/blob/master/rmw/include/rmw/impl/cpp/macros.hpp#L74 (and to help debugging the broken tests)

before: http://ci.ros2.org/view/nightly/job/nightly_linux_release/119/testReport/(root)/test_pendulum_teleop__rmw_connext_cpp/test_executable/
after: http://ci.ros2.org/job/ci_linux/1591/testReport/(root)/test_pendulum_teleop__rmw_connext_cpp/test_executable/