### PR TITLE
wrap Connext libraries in --no-as-needed

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -305,6 +305,8 @@ if(Connext_FOUND)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(Connext_LIBRARIES "-Wl,--no-as-needed" ${Connext_LIBRARIES} "-Wl,--as-needed")
+
     # check with which ABI the Connext libraries are built
     configure_file(
       "${connext_cmake_module_DIR}/check_abi.cmake"


### PR DESCRIPTION
Replaces #173, requires ament/ament_cmake#75.