### PR TITLE
Correct null pointer checks

### DIFF
--- a/rmw_connext_dynamic_cpp/src/templates.hpp
+++ b/rmw_connext_dynamic_cpp/src/templates.hpp
@@ -520,12 +520,12 @@ bool set_value_with_different_types(
   T * ros_values = nullptr;
   if (member->is_array_) {
     size_t array_size = set_array_size_and_values<Id>(member, ros_message, ros_values);
-    if (!ros_values) {
-      RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
-      return false;
-    }
     DDSType * values = nullptr;
     if (array_size > 0) {
+      if (!ros_values) {
+        RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
+        return false;
+      }
       values = static_cast<DDSType *>(rmw_allocate(sizeof(DDSType) * array_size));
       if (!values) {
         RMW_SET_ERROR_MSG("failed to allocate memory");
@@ -570,11 +570,11 @@ set_value_with_different_types<rosidl_typesupport_introspection_cpp::ROS_TYPE_BO
     if (member->array_size_ && !member->is_upper_bound_) {
       bool * ros_values = nullptr;
       array_size = set_array_size_and_values<Id>(member, ros_message, ros_values);
-      if (!ros_values) {
-        RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
-        return false;
-      }
       if (array_size > 0) {
+        if (!ros_values) {
+          RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
+          return false;
+        }
         values = static_cast<DDS_Boolean *>(rmw_allocate(sizeof(DDS_Boolean) * array_size));
         if (!values) {
           RMW_SET_ERROR_MSG("failed to allocate memory");
@@ -637,7 +637,7 @@ bool set_value<rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING>(
     size_t array_size =
       set_array_size_and_values<rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING>(
       member, ros_message, ros_values);
-    if (!ros_values) {
+    if (!ros_values && array_size) {
       RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
       return false;
     }
@@ -708,7 +708,7 @@ bool set_value<rosidl_typesupport_introspection_c__ROS_TYPE_STRING>(
       return false;
     }
     size_t array_size = set_array_size_and_values<Id>(member, ros_message, ros_values);
-    if (!ros_values) {
+    if (!ros_values && array_size > 0) {
       RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
       return false;
     }
@@ -1153,12 +1153,12 @@ bool get_value_with_different_types(
       return false;
     }
     resize_array_and_get_values<Id>(ros_values, ros_message, member, array_size);
-    if (!ros_values) {
-      RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
-      return false;
-    }
 
     if (array_size > 0) {
+      if (!ros_values) {
+        RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
+        return false;
+      }
       DDSType * values =
         static_cast<DDSType *>(rmw_allocate(sizeof(DDSType) * array_size));
       if (!values) {
@@ -1236,7 +1236,7 @@ get_value_with_different_types<rosidl_typesupport_introspection_cpp::ROS_TYPE_BO
       if (member->array_size_ && !member->is_upper_bound_) {
         bool * ros_values = nullptr;
         resize_array_and_get_values<Id>(ros_values, ros_message, member, array_size);
-        if (!ros_values) {
+        if (!ros_values && array_size > 0) {
           RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
           return false;
         }

--- a/rmw_connext_dynamic_cpp/src/templates.hpp
+++ b/rmw_connext_dynamic_cpp/src/templates.hpp
@@ -637,7 +637,7 @@ bool set_value<rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING>(
     size_t array_size =
       set_array_size_and_values<rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING>(
       member, ros_message, ros_values);
-    if (!ros_values && array_size) {
+    if (!ros_values && array_size > 0) {
       RMW_SET_ERROR_MSG("failed to cast ros_values from message array");
       return false;
     }


### PR DESCRIPTION
Should fix the test_communication failures in connext dynamic.

[![Build Status](http://ci.ros2.org/job/ci_linux/badge/icon)](http://ci.ros2.org/job/ci_linux/)
[![Build Status](http://ci.ros2.org/job/ci_osx/1235//badge/icon)](http://ci.ros2.org/job/ci_osx/1235/)