### PR TITLE
expose template declaration publically and unify naming

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -63,7 +63,7 @@
 // Pass an object with a typesupport identifier member to compare
 #define RMW_CONNEXT_CHECK_TYPESUPPORT_IDENTIFIER(TYPESUPPORT) \
   if (TYPESUPPORT->typesupport_identifier !=  /* NOLINT */ \
-    rosidl_typesupport_connext_cpp::typesupport_connext_identifier && \
+    rosidl_typesupport_connext_cpp::typesupport_identifier && \
     TYPESUPPORT->typesupport_identifier != rosidl_typesupport_connext_c__identifier) \
   { \
     char __msg[1024]; \
@@ -73,8 +73,8 @@
       "('%s' (%p), '%s' (%p))", \
       TYPESUPPORT->typesupport_identifier, \
       TYPESUPPORT->typesupport_identifier, \
-      rosidl_typesupport_connext_cpp::typesupport_connext_identifier, \
-      rosidl_typesupport_connext_cpp::typesupport_connext_identifier, \
+      rosidl_typesupport_connext_cpp::typesupport_identifier, \
+      rosidl_typesupport_connext_cpp::typesupport_identifier, \
       rosidl_typesupport_connext_c__identifier, \
       rosidl_typesupport_connext_c__identifier); \
     RMW_SET_ERROR_MSG(__msg); \

--- a/rmw_connext_dynamic_cpp/src/publish_take.cpp
+++ b/rmw_connext_dynamic_cpp/src/publish_take.cpp
@@ -23,7 +23,7 @@ bool using_introspection_c_typesupport(const char * typesupport_identifier)
 bool using_introspection_cpp_typesupport(const char * typesupport_identifier)
 {
   return typesupport_identifier ==
-         rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier;
+         rosidl_typesupport_introspection_cpp::typesupport_identifier;
 }
 
 bool _publish(DDS_DynamicData * dynamic_data, const void * ros_message,

--- a/rosidl_typesupport_connext_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_connext_cpp/CMakeLists.txt
@@ -48,6 +48,8 @@ target_include_directories(${PROJECT_NAME}
 )
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_typesupport_cpp")
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/identifier.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/identifier.hpp
@@ -21,7 +21,7 @@ namespace rosidl_typesupport_connext_cpp
 {
 
 ROSIDL_TYPESUPPORT_CONNEXT_CPP_IMPORT
-extern const char * typesupport_connext_identifier;
+extern const char * typesupport_identifier;
 
 }  // namespace rosidl_typesupport_connext_cpp
 

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
@@ -23,18 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_message_type_support_handle.
 #include <rosidl_generator_cpp/message_type_support_decl.hpp>
+// Provides the declaration of the function template
+#include "rosidl_typesupport_connext_cpp/message_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC.
-#include <rosidl_typesupport_connext_cpp/visibility_control.h>
-
-namespace rosidl_typesupport_connext_cpp
-{
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
-const rosidl_message_type_support_t * get_message_type_support_handle_connext();
-
-}  // namespace rosidl_typesupport_connext_cpp
+#include "rosidl_typesupport_connext_cpp/visibility_control.h"
 
 namespace rosidl_generator_cpp
 {
@@ -49,7 +41,7 @@ const rosidl_message_type_support_t * get_message_type_support_handle()
   // message library. This is intentional to allow the linker to pick the
   // correct implementation specific message library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_connext_cpp::get_message_type_support_handle_connext<T>();
+  return ::rosidl_typesupport_connext_cpp::get_message_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
@@ -23,18 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_service_type_support_handle.
 #include <rosidl_generator_cpp/service_type_support_decl.hpp>
+// Provides the declaration of the function template
+#include "rosidl_typesupport_connext_cpp/service_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC.
-#include <rosidl_typesupport_connext_cpp/visibility_control.h>
-
-namespace rosidl_typesupport_connext_cpp
-{
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
-const rosidl_service_type_support_t * get_service_type_support_handle_connext();
-
-}  // namespace rosidl_typesupport_connext_cpp
+#include "rosidl_typesupport_connext_cpp/visibility_control.h"
 
 namespace rosidl_generator_cpp
 {
@@ -49,7 +41,7 @@ const rosidl_service_type_support_t * get_service_type_support_handle()
   // service library. This is intentional to allow the linker to pick the
   // correct implementation specific service library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_connext_cpp::get_service_type_support_handle_connext<T>();
+  return ::rosidl_typesupport_connext_cpp::get_service_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/message_type_support_decl.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/message_type_support_decl.hpp
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_CONNEXT_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_CONNEXT_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_message_type_support_t struct.
+#include <rosidl_generator_c/message_type_support_struct.h>
+// Provides visibility macros like ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC.
 #include <rosidl_typesupport_connext_cpp/visibility_control.h>
 
 namespace rosidl_typesupport_connext_cpp
 {
 
-ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
-const char * typesupport_identifier = "connext_static_cpp";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_typesupport_connext_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_CONNEXT_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/service_type_support_decl.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/service_type_support_decl.hpp
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_CONNEXT_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_CONNEXT_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_service_type_support_t struct.
+#include <rosidl_generator_c/service_type_support.h>
+// Provides visibility macros like ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC.
 #include <rosidl_typesupport_connext_cpp/visibility_control.h>
 
 namespace rosidl_typesupport_connext_cpp
 {
 
-ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
-const char * typesupport_identifier = "connext_static_cpp";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_CONNEXT_CPP_PUBLIC
+const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_typesupport_connext_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_CONNEXT_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
@@ -323,7 +323,7 @@ static message_type_support_callbacks_t callbacks = {
 };
 
 static rosidl_message_type_support_t handle = {
-  rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+  rosidl_typesupport_connext_cpp::typesupport_identifier,
   &callbacks
 };
 
@@ -339,7 +339,7 @@ namespace rosidl_typesupport_connext_cpp
 template<>
 ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
 const rosidl_message_type_support_t *
-get_message_type_support_handle_connext<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
+get_message_type_support_handle<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
 {
   return &@(spec.base_type.pkg_name)::@(subfolder)::typesupport_connext_cpp::handle;
 }

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
@@ -361,7 +361,7 @@ static service_type_support_callbacks_t callbacks = {
 };
 
 static rosidl_service_type_support_t handle = {
-  rosidl_typesupport_connext_cpp::typesupport_connext_identifier,
+  rosidl_typesupport_connext_cpp::typesupport_identifier,
   &callbacks
 };
 
@@ -377,7 +377,7 @@ namespace rosidl_typesupport_connext_cpp
 template<>
 ROSIDL_TYPESUPPORT_CONNEXT_CPP_EXPORT
 const rosidl_service_type_support_t *
-get_service_type_support_handle_connext<@(spec.pkg_name)::srv::@(spec.srv_name)>()
+get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
   return &@(spec.pkg_name)::srv::typesupport_connext_cpp::handle;
 }


### PR DESCRIPTION
This will unify the symbols across the type support packages so that they only differ in the namespace.

Connect to ros2/rosidl_typesupport#1.