### PR TITLE
Topic names

### DIFF
--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -1878,7 +1878,10 @@ rmw_get_topic_names_and_types(
   rmw_topic_names_and_types_t * topic_names_and_types)
 {
   return get_topic_names_and_types(rti_connext_identifier, node,
-           topic_names_and_types);
+           topic_names_and_types,
+           ros_topics_prefix,
+           ros_service_requester_prefix,
+           ros_service_response_prefix);
 }
 
 rmw_ret_t
@@ -1908,7 +1911,12 @@ rmw_count_publishers(
   const char * topic_name,
   size_t * count)
 {
-  return count_publishers(rti_connext_identifier, node, topic_name, count);
+  return count_publishers(rti_connext_identifier, node,
+    topic_name,
+    ros_topics_prefix,
+    ros_service_requester_prefix,
+    ros_service_response_prefix,
+    count);
 }
 
 rmw_ret_t
@@ -1917,7 +1925,12 @@ rmw_count_subscribers(
   const char * topic_name,
   size_t * count)
 {
-  return count_subscribers(rti_connext_identifier, node, topic_name, count);
+  return count_subscribers(rti_connext_identifier, node,
+    topic_name,
+    ros_topics_prefix,
+    ros_service_requester_prefix,
+    ros_service_response_prefix,
+    count);
 }
 
 rmw_ret_t

--- a/rmw_connext_cpp/src/functions.cpp
+++ b/rmw_connext_cpp/src/functions.cpp
@@ -1912,11 +1912,11 @@ rmw_count_publishers(
   size_t * count)
 {
   return count_publishers(rti_connext_identifier, node,
-    topic_name,
-    ros_topics_prefix,
-    ros_service_requester_prefix,
-    ros_service_response_prefix,
-    count);
+           topic_name,
+           ros_topics_prefix,
+           ros_service_requester_prefix,
+           ros_service_response_prefix,
+           count);
 }
 
 rmw_ret_t
@@ -1926,11 +1926,11 @@ rmw_count_subscribers(
   size_t * count)
 {
   return count_subscribers(rti_connext_identifier, node,
-    topic_name,
-    ros_topics_prefix,
-    ros_service_requester_prefix,
-    ros_service_response_prefix,
-    count);
+           topic_name,
+           ros_topics_prefix,
+           ros_service_requester_prefix,
+           ros_service_response_prefix,
+           count);
 }
 
 rmw_ret_t

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/shared_functions.hpp
@@ -506,12 +506,14 @@ wait(const char * implementation_identifier,
   return RMW_RET_OK;
 }
 
-
 RMW_CONNEXT_SHARED_CPP_PUBLIC
 rmw_ret_t
 get_topic_names_and_types(const char * implementation_identifier,
   const rmw_node_t * node,
-  rmw_topic_names_and_types_t * topic_names_and_types);
+  rmw_topic_names_and_types_t * topic_names_and_types,
+  const char * const ros_topic_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix);
 
 RMW_CONNEXT_SHARED_CPP_PUBLIC
 rmw_ret_t
@@ -524,6 +526,9 @@ rmw_ret_t
 count_publishers(const char * implementation_identifier,
   const rmw_node_t * node,
   const char * topic_name,
+  const char * const ros_topics_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix,
   size_t * count);
 
 RMW_CONNEXT_SHARED_CPP_PUBLIC
@@ -531,6 +536,9 @@ rmw_ret_t
 count_subscribers(const char * implementation_identifier,
   const rmw_node_t * node,
   const char * topic_name,
+  const char * const ros_topics_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix,
   size_t * count);
 
 RMW_CONNEXT_SHARED_CPP_PUBLIC

--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -805,7 +805,7 @@ _filter_ros_prefix(
 {
   auto prefixes = {ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix};
   for (auto prefix : prefixes) {
-    if (topic_name.rfind(std::string(prefix) + "/") == 0) {
+    if (topic_name.rfind(std::string(prefix) + "/", 0) == 0) {
       return topic_name.substr(strlen(ros_topic_prefix));
     }
   }

--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -190,7 +190,8 @@ init()
   return RMW_RET_OK;
 }
 
-rmw_ret_t check_attach_condition_error(DDS::ReturnCode_t retcode)
+rmw_ret_t
+check_attach_condition_error(DDS::ReturnCode_t retcode)
 {
   if (retcode == DDS_RETCODE_OK) {
     return RMW_RET_OK;
@@ -794,11 +795,31 @@ trigger_guard_condition(const char * implementation_identifier,
   return RMW_RET_OK;
 }
 
+inline
+std::string
+_filter_ros_prefix(
+  const std::string & topic_name,
+  const char * const ros_topic_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix)
+{
+  auto prefixes = {ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix};
+  for (auto prefix : prefixes) {
+    if (topic_name.rfind(std::string(prefix) + "/") == 0) {
+      return topic_name.substr(strlen(ros_topic_prefix));
+    }
+  }
+  return topic_name;
+}
+
 rmw_ret_t
 get_topic_names_and_types(
   const char * implementation_identifier,
   const rmw_node_t * node,
-  rmw_topic_names_and_types_t * topic_names_and_types)
+  rmw_topic_names_and_types_t * topic_names_and_types,
+  const char * const ros_topic_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix)
 {
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");
@@ -830,12 +851,18 @@ get_topic_names_and_types(
   std::map<std::string, std::set<std::string>> topics_with_multiple_types;
   for (auto it : node_info->publisher_listener->topic_names_and_types) {
     for (auto & jt : it.second) {
-      topics_with_multiple_types[it.first].insert(jt);
+      // truncate ros specific prefix
+      auto topic_fqdn = _filter_ros_prefix(
+          it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+      topics_with_multiple_types[topic_fqdn].insert(jt);
     }
   }
   for (auto it : node_info->subscriber_listener->topic_names_and_types) {
     for (auto & jt : it.second) {
-      topics_with_multiple_types[it.first].insert(jt);
+      // truncate ros specific prefix
+      auto topic_fqdn = _filter_ros_prefix(
+          it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+      topics_with_multiple_types[topic_fqdn].insert(jt);
     }
   }
 
@@ -958,6 +985,9 @@ rmw_ret_t
 count_publishers(const char * implementation_identifier,
   const rmw_node_t * node,
   const char * topic_name,
+  const char * const ros_topic_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix,
   size_t * count)
 {
   if (!node) {
@@ -988,7 +1018,17 @@ count_publishers(const char * implementation_identifier,
   }
 
   const auto & topic_names_and_types = node_info->publisher_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
+  auto it = std::find_if(
+    topic_names_and_types.begin(),
+    topic_names_and_types.end(),
+    [&] (auto tnt) -> bool {
+      auto fqdn = _filter_ros_prefix(
+          tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+      if (fqdn == topic_name) {
+        return true;
+      }
+      return false;
+  });
   if (it == topic_names_and_types.end()) {
     *count = 0;
   } else {
@@ -1001,6 +1041,9 @@ rmw_ret_t
 count_subscribers(const char * implementation_identifier,
   const rmw_node_t * node,
   const char * topic_name,
+  const char * const ros_topic_prefix,
+  const char * const ros_service_requester_prefix,
+  const char * const ros_service_response_prefix,
   size_t * count)
 {
   if (!node) {
@@ -1031,7 +1074,17 @@ count_subscribers(const char * implementation_identifier,
   }
 
   const auto & topic_names_and_types = node_info->subscriber_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
+  auto it = std::find_if(
+    topic_names_and_types.begin(),
+    topic_names_and_types.end(),
+    [&] (auto tnt) -> bool {
+      auto fqdn = _filter_ros_prefix(
+          tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+      if (fqdn == topic_name) {
+        return true;
+      }
+      return false;
+  });
   if (it == topic_names_and_types.end()) {
     *count = 0;
   } else {

--- a/rmw_connext_shared_cpp/src/shared_functions.cpp
+++ b/rmw_connext_shared_cpp/src/shared_functions.cpp
@@ -853,7 +853,7 @@ get_topic_names_and_types(
     for (auto & jt : it.second) {
       // truncate ros specific prefix
       auto topic_fqdn = _filter_ros_prefix(
-          it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+        it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
       topics_with_multiple_types[topic_fqdn].insert(jt);
     }
   }
@@ -861,7 +861,7 @@ get_topic_names_and_types(
     for (auto & jt : it.second) {
       // truncate ros specific prefix
       auto topic_fqdn = _filter_ros_prefix(
-          it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+        it.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
       topics_with_multiple_types[topic_fqdn].insert(jt);
     }
   }
@@ -1021,13 +1021,13 @@ count_publishers(const char * implementation_identifier,
   auto it = std::find_if(
     topic_names_and_types.begin(),
     topic_names_and_types.end(),
-    [&] (auto tnt) -> bool {
-      auto fqdn = _filter_ros_prefix(
-          tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
-      if (fqdn == topic_name) {
-        return true;
-      }
-      return false;
+    [&](auto tnt) -> bool {
+    auto fqdn = _filter_ros_prefix(
+      tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+    if (fqdn == topic_name) {
+      return true;
+    }
+    return false;
   });
   if (it == topic_names_and_types.end()) {
     *count = 0;
@@ -1077,13 +1077,13 @@ count_subscribers(const char * implementation_identifier,
   auto it = std::find_if(
     topic_names_and_types.begin(),
     topic_names_and_types.end(),
-    [&] (auto tnt) -> bool {
-      auto fqdn = _filter_ros_prefix(
-          tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
-      if (fqdn == topic_name) {
-        return true;
-      }
-      return false;
+    [&](auto tnt) -> bool {
+    auto fqdn = _filter_ros_prefix(
+      tnt.first, ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix);
+    if (fqdn == topic_name) {
+      return true;
+    }
+    return false;
   });
   if (it == topic_names_and_types.end()) {
     *count = 0;


### PR DESCRIPTION
connects to ros2/rmw_fastrtps#114

this should fix the inconsistency with `rclcpp::Node::count_subscribers` and `rclcpp::Node::count_publishers` as well as `get_topic_names_and_types`.

The function truncates the internal topic fqdn in the form of `rt/my_namespace/my_topic` into `/my_namespace/my_topic`