### PR TITLE
update to work with Connext 5.3.0

### DIFF
--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -69,7 +69,7 @@ get_node_names(
 
 
   for (auto i = 1; i < length; ++i) {
-    ParticipantBuiltinTopicData pbtd;
+    DDS::ParticipantBuiltinTopicData pbtd;
     auto dds_ret = participant->get_discovered_participant_data(pbtd, handles[i - 1]);
     const char * name = pbtd.participant_name.name;
     if (!name || dds_ret != DDS_RETCODE_OK) {

--- a/rmw_connext_shared_cpp/src/waitset.cpp
+++ b/rmw_connext_shared_cpp/src/waitset.cpp
@@ -129,16 +129,16 @@ destroy_waitset(const char * implementation_identifier, rmw_waitset_t * waitset)
   // Explicitly call destructor since the "placement new" was used
   if (waitset_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
-      waitset_info->active_conditions->~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      waitset_info->active_conditions->~DDSConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
     rmw_free(waitset_info->active_conditions);
   }
   if (waitset_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
-      waitset_info->attached_conditions->~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      waitset_info->attached_conditions->~DDSConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
     rmw_free(waitset_info->attached_conditions);
   }
   if (waitset_info->waitset) {
-    RMW_TRY_DESTRUCTOR(waitset_info->waitset->~WaitSet(), WaitSet, result = RMW_RET_ERROR)
+    RMW_TRY_DESTRUCTOR(waitset_info->waitset->~DDSWaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(waitset_info->waitset);
   }
   waitset_info = nullptr;


### PR DESCRIPTION
These minor changes are necessary to compile locally against Connext 5.3.0.

The changes work fine with Connext 5.2.3 on the buildfarm:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2888)](http://ci.ros2.org/job/ci_linux/2888/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2327)](http://ci.ros2.org/job/ci_osx/2327/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3012)](http://ci.ros2.org/job/ci_windows/3012/)

Ready for review.

Wait for #237 before merging though...