### PR TITLE
Rename type_support_commons -> type_support_common

### DIFF
--- a/rmw_connext_cpp/src/rmw_client.cpp
+++ b/rmw_connext_cpp/src/rmw_client.cpp
@@ -24,7 +24,7 @@
 
 #include "identifier.hpp"
 #include "process_topic_and_service_names.hpp"
-#include "type_support_commons.hpp"
+#include "type_support_common.hpp"
 #include "types/connext_static_client_info.hpp"
 
 // Uncomment this to get extra console output about discovery.

--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -25,7 +25,7 @@
 
 #include "identifier.hpp"
 #include "process_topic_and_service_names.hpp"
-#include "type_support_commons.hpp"
+#include "type_support_common.hpp"
 #include "types/connext_static_publisher_info.hpp"
 
 // Uncomment this to get extra console output about discovery.

--- a/rmw_connext_cpp/src/rmw_service.cpp
+++ b/rmw_connext_cpp/src/rmw_service.cpp
@@ -23,7 +23,7 @@
 
 #include "identifier.hpp"
 #include "process_topic_and_service_names.hpp"
-#include "type_support_commons.hpp"
+#include "type_support_common.hpp"
 #include "types/connext_static_service_info.hpp"
 
 // Uncomment this to get extra console output about discovery.

--- a/rmw_connext_cpp/src/rmw_subscription.cpp
+++ b/rmw_connext_cpp/src/rmw_subscription.cpp
@@ -24,7 +24,7 @@
 
 #include "identifier.hpp"
 #include "process_topic_and_service_names.hpp"
-#include "type_support_commons.hpp"
+#include "type_support_common.hpp"
 #include "types/connext_static_subscriber_info.hpp"
 
 // Uncomment this to get extra console output about discovery.

--- a/rmw_connext_cpp/src/type_support_common.hpp
+++ b/rmw_connext_cpp/src/type_support_common.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPE_SUPPORT_COMMONS_HPP_
-#define TYPE_SUPPORT_COMMONS_HPP_
+#ifndef TYPE_SUPPORT_COMMON_HPP_
+#define TYPE_SUPPORT_COMMON_HPP_
 
 #include <string>
 
@@ -94,4 +94,4 @@ _create_type_name(
     "::" + sep + "::dds_::" + callbacks->message_name + "_";
 }
 
-#endif  // TYPE_SUPPORT_COMMONS_HPP_
+#endif  // TYPE_SUPPORT_COMMON_HPP_


### PR DESCRIPTION
thanks for indulging me

Standard CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2911)](http://ci.ros2.org/job/ci_linux/2911/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=389)](http://ci.ros2.org/job/ci_linux-aarch64/389/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2354)](http://ci.ros2.org/job/ci_osx/2354/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3033)](http://ci.ros2.org/job/ci_windows/3033/)

CI including connext dynamic:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2910)](http://ci.ros2.org/job/ci_linux/2910/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=388)](http://ci.ros2.org/job/ci_linux-aarch64/388/) (no new info provided)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2353)](http://ci.ros2.org/job/ci_osx/2353/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3032)](http://ci.ros2.org/job/ci_windows/3032/)