### PR TITLE
fix memory leak

### DIFF
--- a/rmw_connext_cpp/src/process_topic_and_service_names.cpp
+++ b/rmw_connext_cpp/src/process_topic_and_service_names.cpp
@@ -60,7 +60,6 @@ _process_topic_name(
       *partition_str = DDS_String_dup(concat_str);
       allocator.deallocate(concat_str, allocator.state);
     }
-    // Connext will call deallocate on this, passing ownership to connext
     *topic_str = DDS_String_dup(name_tokens.data[1]);
   } else {
     RMW_SET_ERROR_MSG("incorrectly formatted topic name")


### PR DESCRIPTION
introduced in #221 (see https://github.com/ros2/rmw_connext/pull/221#discussion_r136465335).

Only ownership of `partition_str` is being passed to Connext. `topic_str` never changes ownership. Both still need to be cleaned up in case of errors.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3138)](http://ci.ros2.org/job/ci_linux/3138/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2497)](http://ci.ros2.org/job/ci_osx/2497/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3193)](http://ci.ros2.org/job/ci_windows/3193/)