### PR TITLE
check return values of all narrow calls

### DIFF
--- a/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
@@ -437,6 +437,10 @@ take(
 
   @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataReader * data_reader =
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataReader::narrow(topic_reader);
+  if (!data_reader) {
+    fprintf(stderr, "failed to narrow data reader\n");
+    return false;
+  }
 
   @(__dds_msg_type_prefix)Seq dds_messages;
   DDS_SampleInfoSeq sample_infos;

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
@@ -165,6 +165,10 @@ publish__@(spec.base_type.type)(
   if (success) {
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter * data_writer =
       @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter::narrow(topic_writer);
+    if (!data_writer) {
+      fprintf(stderr, "failed to narrow data writer\n");
+      return false;
+    }
     DDS_ReturnCode_t status = data_writer->write(*dds_message, DDS_HANDLE_NIL);
     success = status == DDS_RETCODE_OK;
   }
@@ -249,6 +253,10 @@ take__@(spec.base_type.type)(
 
   @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataReader * data_reader =
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataReader::narrow(topic_reader);
+  if (!data_reader) {
+    fprintf(stderr, "failed to narrow data reader\n");
+    return false;
+  }
 
   @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_Seq dds_messages;
   DDS_SampleInfoSeq sample_infos;

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
@@ -165,13 +165,12 @@ publish__@(spec.base_type.type)(
   if (success) {
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter * data_writer =
       @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter::narrow(topic_writer);
-    if (data_writer != static_cast<@(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter *>(NULL)) {
-      DDS_ReturnCode_t status = data_writer->write(*dds_message, DDS_HANDLE_NIL);
-      success = (status == DDS_RETCODE_OK);
-    }
-    else {
+    if (!data_writer) {
       fprintf(stderr, "failed to narrow data writer\n");
       success = false;
+    } else {
+      DDS_ReturnCode_t status = data_writer->write(*dds_message, DDS_HANDLE_NIL);
+      success = status == DDS_RETCODE_OK;
     }
   }
 

--- a/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/msg__type_support.cpp.em
@@ -165,12 +165,14 @@ publish__@(spec.base_type.type)(
   if (success) {
     @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter * data_writer =
       @(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter::narrow(topic_writer);
-    if (!data_writer) {
-      fprintf(stderr, "failed to narrow data writer\n");
-      return false;
+    if (data_writer != static_cast<@(spec.base_type.pkg_name)::@(subfolder)::dds_::@(spec.base_type.type)_DataWriter *>(NULL)) {
+      DDS_ReturnCode_t status = data_writer->write(*dds_message, DDS_HANDLE_NIL);
+      success = (status == DDS_RETCODE_OK);
     }
-    DDS_ReturnCode_t status = data_writer->write(*dds_message, DDS_HANDLE_NIL);
-    success = status == DDS_RETCODE_OK;
+    else {
+      fprintf(stderr, "failed to narrow data writer\n");
+      success = false;
+    }
   }
 
   DDS_ReturnCode_t status =


### PR DESCRIPTION
Original issue: https://github.com/ros2/rmw_connext/issues/246
I added return value checks after each narrow call.
If the returned value is NULL I print out diagnostics into stderr and return false (error) value.
