### PR TITLE
add argument to invocation to get returncode 0 for both connext 5.2.4…

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -327,7 +327,7 @@ endif()
 if(Connext_DDSGEN_SERVER)
   # check that the generator is invocable / finds a Java runtime environment
   execute_process(
-    COMMAND "${Connext_DDSGEN_SERVER}"
+    COMMAND "${Connext_DDSGEN_SERVER}" "-version"
     RESULT_VARIABLE _retcode
     OUTPUT_QUIET ERROR_QUIET)
   if(NOT _retcode EQUAL 0)


### PR DESCRIPTION
… and 5.3.0

I was looking into why my local builds became so much slower since I switched to connext 5.3.0.
The part that seems much slower is the invocation of the `rtiddsgen_server` executable in the Connext cmake module.

While I haven't found yet how to improve the speed in the invocation of the generator (they seem to be just as fast when running them in a shell), I noticed that none of our builds were using the `ddsgen_server` since we upgraded. The reason is that the return code when invoking the executable without argument is not the same between 5.2.X and 5.3.0.
Adding the `-version` argument seems to bring us back to both returning the code 0.

You can confirm it by looking for "/bin/rtiddsgen" in:
the last nightly: http://ci.ros2.org/view/nightly/job/nightly_linux_debug/602/consoleFull
the job with this change: http://ci.ros2.org/job/ci_linux/3295/consoleFull