### PR TITLE
Remove rmw_connext dead code

### DIFF
--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -252,9 +252,7 @@ fail:
     DDS_String_free(topic_str);
     topic_str = nullptr;
   }
-  if (publisher) {
-    rmw_publisher_free(publisher);
-  }
+
   // Assumption: participant is valid.
   if (dds_publisher) {
     if (topic_writer) {

--- a/rmw_connext_cpp/src/rmw_subscription.cpp
+++ b/rmw_connext_cpp/src/rmw_subscription.cpp
@@ -250,9 +250,7 @@ fail:
     DDS_String_free(topic_str);
     topic_str = nullptr;
   }
-  if (subscription) {
-    rmw_subscription_free(subscription);
-  }
+
   // Assumption: participant is valid.
   if (dds_subscriber) {
     if (topic_reader) {


### PR DESCRIPTION
Dead code in API `rmw_create_subscription()`
the condition "`subscription`" cannot be true in the "`fail`"
clauses and the execution never reaches this statement:

```
if (subscription) {
    rmw_subscription_free(subscription);
    }
```

the "`subscribtion`" will be finally free by
`rmw_destroy_subscription()` when it's not a nullptr

Dead code in API `rmw_create_publisher()`
the condition "`publisher`" cannot be true in the "`fail`"
clauses, so the execution cannot reach this statement:

```
if (publisher) {
    rmw_publisher_free(publisher);
    }
```

the "`publisher`" will be finally free by
`rmw_destroy_publisher()` when it's not a nullptr

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>