### PR TITLE
Remove connext workaround

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -313,8 +313,6 @@ if(Connext_FOUND)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(Connext_LIBRARIES "-Wl,--no-as-needed" ${Connext_LIBRARIES} "-Wl,--as-needed")
-
     # check with which ABI the Connext libraries are built
     configure_file(
       "${connext_cmake_module_DIR}/check_abi.cmake"

--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic,--no-as-needed)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 include_directories(@Connext_INCLUDE_DIRS@)

--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wl,--no-as-needed)
+  add_compile_options(-Wall -Wextra -Wpedantic,--no-as-needed)
 endif()
 
 include_directories(@Connext_INCLUDE_DIRS@)


### PR DESCRIPTION
From what I understand this was only necessary for Ubuntu connext builds with gcc4.8.2 (https://community.rti.com/static/documentation/connext-dds/5.3.0/doc/manuals/connext_dds/RTI_ConnextDDS_CoreLibraries_PlatformNotes.pdf).
As we now target connext 5.3.0 that is built with gcc5.4 this doesnt apply anymore.

I don't have the full context, relevant discussion: https://github.com/ros2/rcl/pull/55#issuecomment-224669618

If we decide to keep it it may make sense to [export these flags](https://github.com/ros2/rmw_connext/pull/173) (https://github.com/ros2/rmw_connext/pull/178#issue-161793493) to avoid [workarounds in downstream packages](https://github.com/ros2/rcl/blob/b41d4e333e2b977f7c93a18009cd93a8db5e87f0/rcl/test/CMakeLists.txt#L211-L220)

* Linux Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3778)](http://ci.ros2.org/job/ci_linux/3778/)

* Linux Release [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3779)](http://ci.ros2.org/job/ci_linux/3779/)

Edit: New ci:
* Linux Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3781)](http://ci.ros2.org/job/ci_linux/3781/)

* Linux Release [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3782)](http://ci.ros2.org/job/ci_linux/3782/)