### PR TITLE
compile all cpp files

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -313,6 +313,8 @@ if(Connext_FOUND)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(Connext_LIBRARIES "-Wl,--no-as-needed" ${Connext_LIBRARIES} "-Wl,--as-needed")
+
     # check with which ABI the Connext libraries are built
     configure_file(
       "${connext_cmake_module_DIR}/check_abi.cmake"

--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wl,--no-as-needed)
 endif()
 
 include_directories(@Connext_INCLUDE_DIRS@)

--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -69,10 +69,13 @@ register_rmw_implementation(
 add_library(
   rmw_connext_cpp
   SHARED
+  src/get_client.cpp
   src/get_participant.cpp
+  src/get_publisher.cpp
+  src/get_service.cpp
+  src/get_subscriber.cpp
   src/identifier.cpp
   src/process_topic_and_service_names.cpp
-  src/rmw_logging.cpp
   src/rmw_client.cpp
   src/rmw_compare_gid_equals.cpp
   src/rmw_count.cpp
@@ -80,6 +83,7 @@ add_library(
   src/rmw_get_implementation_identifier.cpp
   src/rmw_guard_condition.cpp
   src/rmw_init.cpp
+  src/rmw_logging.cpp
   src/rmw_node.cpp
   src/rmw_node_names.cpp
   src/rmw_publish.cpp


### PR DESCRIPTION
I've noticed that a couple of `.cpp` files in the `src` folder are currently not compiled. As our CI turns out to run just fine, I think these functions are currently not being used anywhere.
Don't know exactly why, but I think I simply forgot them to add when restructuring this package.

I don't run CI/linters on this PR since the files are still taken into considerations by the linters.