### PR TITLE
Disable non-standard TypeCode

### DIFF
--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -92,6 +92,10 @@ create_node(
     return NULL;
   }
 
+  // Disable TypeCode since it increases discovery message size and is replaced by TypeObject
+  // https://community.rti.com/kb/types-matching
+  participant_qos.resource_limits.type_code_max_serialized_length = 0;
+
   if (security_options->security_root_path) {
     // enable some security stuff
     status = DDSPropertyQosPolicyHelper::add_property(


### PR DESCRIPTION
This unblocks ros2/rcl_interfaces#32 and ros2/rclcpp#443. It's a workaround for ros2/rmw_fastrtps#194. In short it disables a nonstandard feature to reduce the size of a message sent during discovery by RTI connext.

To reproduce the issue this works around:

1. Checkout `rcl_interfaces` branch `paremeter_type_array`
1. `RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp listener`
1. `RMW_IMPLEMENTATION=rmw_connext_cpp ros2 run demo_nodes_cpp talker`

Without this PR the node using `rmw_fastrtps_cpp` will spam the console with
```
[RTPS_HISTORY Error] Change payload size of '5100' bytes is larger than the history payload size of '5000' bytes [...]
```

These fail to communicate because RTI sends a very large message during discovery and FastRTPS seems to have a fixed size buffer (5000 bytes) that is too small. The reason RTI's message is so large has to do with its support for DDS-XTYPES.

[RTI connext 5.x partially supports DDS-XTYPES, but versions 4.5f and lower implemented something similar but non-standard](https://community.rti.com/kb/typeobject-and-typecode). The standard version is `TypeObject` and pre-standard is `TypeCode`. These contain full descriptions of the message, so more message fields means more data is sent. For backwards compatibility with 4.5f and below, 5.x versions sends both a `TypeObject` and `TypeCode`.

`TypeObject` and `TypeCode` have a default maximum serialized length of 3072 and 2048 bytes respectively. A message that almost maxes both of these out would exceed FastRTPS's buffer size. However, a message that is even larger causes connext to just not send the field and fall back to matching using the topic name. This means fastrtps and default configured connext will fail to communicate if `TypeObject` + `TypeCode` + (lots of smaller stuff) > 5000 bytes and `TypeObject` < 3072 and `TypeCode` < 2048. The parameter events message with array support falls into this sweet spot.

The fix here is to set the maximum serialized length of `TypeCode` to zero so that connext never sends it.

CI

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4380)](http://ci.ros2.org/job/ci_linux/4380/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1335)](http://ci.ros2.org/job/ci_linux-aarch64/1335/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3576)](http://ci.ros2.org/job/ci_osx/3576/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4432)](http://ci.ros2.org/job/ci_windows/4432/)