### PR TITLE
Use key rti-connext-dds as package key name for connext.

### DIFF
--- a/rmw_connext_cpp/package.xml
+++ b/rmw_connext_cpp/package.xml
@@ -14,22 +14,22 @@
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_depend>connext_cmake_module</build_depend>
-  <build_depend>libndds52-dev</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
   <build_depend>rmw_connext_shared_cpp</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_generator_cpp</build_depend>
+  <build_depend>rosidl_generator_dds_idl</build_depend>
   <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_connext_cpp</build_depend>
-  <build_depend>rosidl_generator_dds_idl</build_depend>
+  <build_depend>rti-connext-dds</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
-  <build_export_depend>libndds52</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
+  <build_export_depend>rti-connext-dds</build_export_depend>
 
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>

--- a/rmw_connext_cpp/package.xml
+++ b/rmw_connext_cpp/package.xml
@@ -22,14 +22,14 @@
   <build_depend>rosidl_generator_dds_idl</build_depend>
   <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_connext_cpp</build_depend>
-  <build_depend>rti-connext-dds</build_depend>
+  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
-  <build_export_depend>rti-connext-dds</build_export_depend>
+  <build_export_depend>rti-connext-dds-5.3.1</build_export_depend>
 
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>

--- a/rmw_connext_dynamic_cpp/package.xml
+++ b/rmw_connext_dynamic_cpp/package.xml
@@ -17,14 +17,14 @@
   <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
-  <build_depend>rti-connext-dds</build_depend>
+  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
-  <build_export_depend>rti-connext-dds</build_export_depend>
+  <build_export_depend>rti-connext-dds-5.3.1</build_export_depend>
 
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>

--- a/rmw_connext_dynamic_cpp/package.xml
+++ b/rmw_connext_dynamic_cpp/package.xml
@@ -11,20 +11,20 @@
 
   <build_depend>connext_cmake_module</build_depend>
   <build_depend>rcutils</build_depend>
-  <build_depend>libndds51-dev</build_depend>
   <build_depend>rmw</build_depend>
   <build_depend>rmw_connext_shared_cpp</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
+  <build_depend>rti-connext-dds</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
-  <build_export_depend>libndds51</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+  <build_export_depend>rti-connext-dds</build_export_depend>
 
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>

--- a/rmw_connext_shared_cpp/package.xml
+++ b/rmw_connext_shared_cpp/package.xml
@@ -15,10 +15,10 @@
   <build_depend>connext_cmake_module</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
-  <build_depend>rti-connext-dds</build_depend>
+  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
-  <build_export_depend>rti-connext-dds</build_export_depend>
+  <build_export_depend>rti-connext-dds-5.3.1</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rmw_connext_shared_cpp/package.xml
+++ b/rmw_connext_shared_cpp/package.xml
@@ -13,12 +13,12 @@
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <build_depend>connext_cmake_module</build_depend>
-  <build_depend>libndds52-dev</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
+  <build_depend>rti-connext-dds</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>
-  <build_export_depend>libndds52</build_export_depend>
+  <build_export_depend>rti-connext-dds</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_typesupport_connext_cpp/package.xml
+++ b/rosidl_typesupport_connext_cpp/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_generator_c</buildtool_depend>
   <buildtool_depend>rosidl_generator_cpp</buildtool_depend>
-  <buildtool_depend>rti-connext-dds</buildtool_depend>
+  <buildtool_depend>rti-connext-dds-5.3.1</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>connext_cmake_module</buildtool_export_depend>
@@ -20,7 +20,7 @@
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>
-  <buildtool_export_depend>rti-connext-dds</buildtool_export_depend>
+  <buildtool_export_depend>rti-connext-dds-5.3.1</buildtool_export_depend>
 
   <build_export_depend>rmw</build_export_depend>
 

--- a/rosidl_typesupport_connext_cpp/package.xml
+++ b/rosidl_typesupport_connext_cpp/package.xml
@@ -9,21 +9,18 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>connext_cmake_module</buildtool_depend>
-  <buildtool_depend>libndds51-dev</buildtool_depend>
-  <buildtool_depend>ndds-tools</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_generator_c</buildtool_depend>
   <buildtool_depend>rosidl_generator_cpp</buildtool_depend>
+  <buildtool_depend>rti-connext-dds</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>connext_cmake_module</buildtool_export_depend>
-  <buildtool_export_depend>libndds51-dev</buildtool_export_depend>
-  <buildtool_export_depend>libndds51</buildtool_export_depend>
-  <buildtool_export_depend>ndds-tools</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>
+  <buildtool_export_depend>rti-connext-dds</buildtool_export_depend>
 
   <build_export_depend>rmw</build_export_depend>
 


### PR DESCRIPTION
Since all connext support is provided by the one package, use a single rosdep key which matches the name of the provided package.

Do we want to add some portion of the package version to the key name as we do in https://github.com/ros2/rmw_opensplice/pull/232 in order to allow for different connext versions both on bionic?