### PR TITLE
Add semicolons to all RCLCPP and RCUTILS macros.

### DIFF
--- a/rmw_connext_shared_cpp/src/demangle.cpp
+++ b/rmw_connext_shared_cpp/src/demangle.cpp
@@ -82,7 +82,7 @@ _demangle_service_from_topic(const std::string & topic_name)
   if (suffix_position == std::string::npos) {
     RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
       "service topic has prefix but no suffix"
-      ", report this: '%s'", topic_name.c_str())
+      ", report this: '%s'", topic_name.c_str());
     return "";
   }
   // strip off the suffix first
@@ -113,7 +113,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
       if (dds_type_name.length() - suffix_position - suffix.length() != 0) {
         RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
           "service type contains '::srv::dds_::' and a suffix, but not at the end"
-          ", report this: '%s'", dds_type_name.c_str())
+          ", report this: '%s'", dds_type_name.c_str());
         continue;
       }
       found_suffix = suffix;
@@ -123,7 +123,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
   if (suffix_position == std::string::npos) {
     RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
       "service type contains '::srv::dds_::' but does not have a suffix"
-      ", report this: '%s'", dds_type_name.c_str())
+      ", report this: '%s'", dds_type_name.c_str());
     return "";
   }
   // everything checks out, reformat it from '<pkg>::srv::dds_::<type><suffix>' to '<pkg>/<type>'

--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -134,7 +134,7 @@ fail:
     if (rcutils_ret != RCUTILS_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_connext_cpp",
-        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
       rcutils_reset_error();
     }
   }
@@ -143,7 +143,7 @@ fail:
     if (rcutils_ret != RCUTILS_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_connext_cpp",
-        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
       rcutils_reset_error();
     }
   }

--- a/rmw_connext_shared_cpp/src/service_names_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/service_names_and_types.cpp
@@ -112,7 +112,7 @@ get_service_names_and_types(
     auto fail_cleanup = [&service_names_and_types]() {
         rmw_ret_t rmw_ret = rmw_names_and_types_fini(service_names_and_types);
         if (rmw_ret != RMW_RET_OK) {
-          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe())
+          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // For each service, store the name, initialize the string array for types, and store all types

--- a/rmw_connext_shared_cpp/src/topic_names_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/topic_names_and_types.cpp
@@ -96,7 +96,7 @@ get_topic_names_and_types(
     auto fail_cleanup = [&topic_names_and_types]() {
         rmw_ret_t rmw_ret = rmw_names_and_types_fini(topic_names_and_types);
         if (rmw_ret != RMW_RET_OK) {
-          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe())
+          RCUTILS_LOG_ERROR("error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // Setup demangling functions based on no_demangle option


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/rcutils/issues/113