### PR TITLE
Fix lint warning from invalid escape sequences

### DIFF
--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -20,7 +20,7 @@ import argparse
 import re
 
 # regular expression / pattern for patch header
-_hdr_pat = re.compile('^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@.*$')
+_hdr_pat = re.compile(r'^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@.*$')
 
 
 def apply_patch(s, patch):


### PR DESCRIPTION
Use raw string for regex pattern to avoid warning.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5348)](http://ci.ros2.org/job/ci_linux/5348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2078)](http://ci.ros2.org/job/ci_linux-aarch64/2078/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4441)](http://ci.ros2.org/job/ci_osx/4441/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5311)](http://ci.ros2.org/job/ci_windows/5311/)