### PR TITLE
refactor to support init options and context

### DIFF
--- a/rmw_connext_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_connext_cpp/src/rmw_guard_condition.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
 #include "rmw_connext_shared_cpp/guard_condition.hpp"
@@ -21,8 +22,15 @@
 extern "C"
 {
 rmw_guard_condition_t *
-rmw_create_guard_condition()
+rmw_create_guard_condition(rmw_context_t * context)
 {
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, NULL);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    init context,
+    context->implementation_identifier,
+    rti_connext_identifier,
+    // TODO(wjwwood): replace this with RMW_RET_INCORRECT_RMW_IMPLEMENTATION when refactored
+    return NULL);
   return create_guard_condition(rti_connext_identifier);
 }
 

--- a/rmw_connext_cpp/src/rmw_init.cpp
+++ b/rmw_connext_cpp/src/rmw_init.cpp
@@ -84,4 +84,18 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   context->impl = nullptr;
   return init();
 }
+
+rmw_ret_t
+rmw_shutdown(rmw_context_t * context)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    context,
+    context->implementation_identifier,
+    rti_connext_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
+  *context = rmw_get_zero_initialized_context();
+  return RMW_RET_OK;
+}
 }  // extern "C"

--- a/rmw_connext_cpp/src/rmw_init.cpp
+++ b/rmw_connext_cpp/src/rmw_init.cpp
@@ -94,7 +94,8 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     rti_connext_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
+  // context impl is explicitly supposed to be nullptr for now, see rmw_init's code
+  // RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
   *context = rmw_get_zero_initialized_context();
   return RMW_RET_OK;
 }

--- a/rmw_connext_cpp/src/rmw_init.cpp
+++ b/rmw_connext_cpp/src/rmw_init.cpp
@@ -12,15 +12,78 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rmw/rmw.h"
+#include "rmw/init.h"
 
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw_connext_shared_cpp/init.hpp"
+
+#include "rmw_connext_cpp/identifier.hpp"
 
 extern "C"
 {
+
 rmw_ret_t
-rmw_init()
+rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t allocator)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(init_options, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RMW_RET_INVALID_ARGUMENT);
+  if (NULL != init_options->implementation_identifier) {
+    RMW_SET_ERROR_MSG("expected zero-initialized init_options");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  init_options->instance_id = 0;
+  init_options->implementation_identifier = rti_connext_identifier;
+  init_options->allocator = allocator;
+  init_options->impl = nullptr;
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+rmw_init_options_copy(const rmw_init_options_t * src, rmw_init_options_t * dst)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(src, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(dst, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    src,
+    src->implementation_identifier,
+    rti_connext_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  if (NULL != dst->implementation_identifier) {
+    RMW_SET_ERROR_MSG("expected zero-initialized dst");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  *dst = *src;
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+rmw_init_options_fini(rmw_init_options_t * init_options)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(init_options, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR(&(init_options->allocator), return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    init_options,
+    init_options->implementation_identifier,
+    rti_connext_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  *init_options = rmw_get_zero_initialized_init_options();
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(options, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    options,
+    options->implementation_identifier,
+    rti_connext_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  context->instance_id = options->instance_id;
+  context->implementation_identifier = rti_connext_identifier;
+  context->impl = nullptr;
   return init();
 }
+
 }  // extern "C"

--- a/rmw_connext_cpp/src/rmw_init.cpp
+++ b/rmw_connext_cpp/src/rmw_init.cpp
@@ -21,7 +21,6 @@
 
 extern "C"
 {
-
 rmw_ret_t
 rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t allocator)
 {
@@ -85,5 +84,4 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   context->impl = nullptr;
   return init();
 }
-
 }  // extern "C"

--- a/rmw_connext_cpp/src/rmw_node.cpp
+++ b/rmw_connext_cpp/src/rmw_node.cpp
@@ -24,11 +24,19 @@ extern "C"
 {
 rmw_node_t *
 rmw_create_node(
+  rmw_context_t * context,
   const char * name,
   const char * namespace_,
   size_t domain_id,
   const rmw_node_security_options_t * security_options)
 {
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, NULL);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    init context,
+    context->implementation_identifier,
+    rti_connext_identifier,
+    // TODO(wjwwood): replace this with RMW_RET_INCORRECT_RMW_IMPLEMENTATION when refactored
+    return NULL);
   return create_node(
     rti_connext_identifier, name, namespace_, domain_id, security_options);
 }

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -275,7 +275,8 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     rti_connext_dynamic_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
+  // context impl is explicitly supposed to be nullptr for now, see rmw_init's code
+  // RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
   *context = rmw_get_zero_initialized_context();
   return RMW_RET_OK;
 }

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -266,6 +266,20 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   return init();
 }
 
+rmw_ret_t
+rmw_shutdown(rmw_context_t * context)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    context,
+    context->implementation_identifier,
+    rti_connext_dynamic_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
+  *context = rmw_get_zero_initialized_context();
+  return RMW_RET_OK;
+}
+
 rmw_node_t *
 rmw_create_node(
   rmw_context_t * context,


### PR DESCRIPTION
Connects to ros2/rmw#154

@serge-nikulin FYI this is an example of what the disruption to an existing rmw implementation will look like for the init options and context changes.