### PR TITLE
Adds missing RMW_CONNEXT_SHARED_CPP_PUBLIC

### DIFF
--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
@@ -66,10 +66,12 @@ public:
     const std::string & type_name,
     EntityType entity_type);
 
+  RMW_CONNEXT_SHARED_CPP_PUBLIC
   virtual void remove_information(
     const DDS_InstanceHandle_t & instance_handle,
     EntityType entity_type);
 
+  RMW_CONNEXT_SHARED_CPP_PUBLIC
   virtual void trigger_graph_guard_condition();
 
   size_t count_topic(const char * topic_name);


### PR DESCRIPTION
This prevents linking errors in Windows such as:

error LNK2019: unresolved external symbol "public: void __cdecl CustomDataReaderListener::add_information(...)"