### PR TITLE
No need to use strcmp, we can compare a std::string with operator== t…

### DIFF
--- a/rmw_connext_shared_cpp/src/node_info_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/node_info_and_types.cpp
@@ -66,7 +66,7 @@ __is_node_match(
     if (name_found != map.end() && ns_found != map.end()) {
       std::string name(name_found->second.begin(), name_found->second.end());
       std::string ns(ns_found->second.begin(), ns_found->second.end());
-      return strcmp(node_name, name.c_str()) == 0 && strcmp(node_namespace, ns.c_str()) == 0;
+      return ((name == node_name) && (ns == node_namespace));
     }
   }
   return false;
@@ -120,8 +120,7 @@ __get_key(
         if (name_found != map.end() && ns_found != map.end()) {
           std::string name(name_found->second.begin(), name_found->second.end());
           std::string ns(ns_found->second.begin(), ns_found->second.end());
-          if (strcmp(node_name, name.c_str()) == 0 &&
-            strcmp(node_namespace, ns.c_str()) == 0)
+          if ((name == node_name) && (ns == node_namespace))
           {
             DDS_BuiltinTopicKey_to_GUID(&key, pbtd.key);
             return RMW_RET_OK;

--- a/rmw_connext_shared_cpp/src/node_info_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/node_info_and_types.cpp
@@ -66,7 +66,7 @@ __is_node_match(
     if (name_found != map.end() && ns_found != map.end()) {
       std::string name(name_found->second.begin(), name_found->second.end());
       std::string ns(ns_found->second.begin(), ns_found->second.end());
-      return ((name == node_name) && (ns == node_namespace));
+      return (name == node_name) && (ns == node_namespace);
     }
   }
   return false;
@@ -120,8 +120,7 @@ __get_key(
         if (name_found != map.end() && ns_found != map.end()) {
           std::string name(name_found->second.begin(), name_found->second.end());
           std::string ns(ns_found->second.begin(), ns_found->second.end());
-          if ((name == node_name) && (ns == node_namespace))
-          {
+          if ((name == node_name) && (ns == node_namespace)) {
             DDS_BuiltinTopicKey_to_GUID(&key, pbtd.key);
             return RMW_RET_OK;
           }


### PR DESCRIPTION
…o a const char*, makes the code easier to read

    * rmw_connext_shared_cpp/src/node_info_and_types.cpp: