### PR TITLE
Make use of DDS namespace instead of DDS_ prefixed versions in global namespace

### DIFF
--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_client_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_client_info.hpp
@@ -24,8 +24,8 @@ extern "C"
 struct ConnextStaticClientInfo
 {
   void * requester_;
-  DDSDataReader * response_datareader_;
-  DDSReadCondition * read_condition_;
+  DDS::DataReader * response_datareader_;
+  DDS::ReadCondition * read_condition_;
   const service_type_support_callbacks_t * callbacks_;
 };
 }  // extern "C"

--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
@@ -27,15 +27,15 @@ extern "C"
 {
 struct ConnextStaticPublisherInfo
 {
-  DDSPublisher * dds_publisher_;
+  DDS::Publisher * dds_publisher_;
   ConnextPublisherListener * listener_;
-  DDSDataWriter * topic_writer_;
+  DDS::DataWriter * topic_writer_;
   const message_type_support_callbacks_t * callbacks_;
   rmw_gid_t publisher_gid;
 };
 }  // extern "C"
 
-class ConnextPublisherListener : public DDSPublisherListener
+class ConnextPublisherListener : public DDS::PublisherListener
 {
 public:
   virtual void on_publication_matched(

--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_service_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_service_info.hpp
@@ -24,8 +24,8 @@ extern "C"
 struct ConnextStaticServiceInfo
 {
   void * replier_;
-  DDSDataReader * request_datareader_;
-  DDSReadCondition * read_condition_;
+  DDS::DataReader * request_datareader_;
+  DDS::ReadCondition * read_condition_;
   const service_type_support_callbacks_t * callbacks_;
 };
 }  // extern "C"

--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
@@ -27,16 +27,16 @@ extern "C"
 {
 struct ConnextStaticSubscriberInfo
 {
-  DDSSubscriber * dds_subscriber_;
+  DDS::Subscriber * dds_subscriber_;
   ConnextSubscriberListener * listener_;
-  DDSDataReader * topic_reader_;
-  DDSReadCondition * read_condition_;
+  DDS::DataReader * topic_reader_;
+  DDS::ReadCondition * read_condition_;
   bool ignore_local_publications;
   const message_type_support_callbacks_t * callbacks_;
 };
 }  // extern "C"
 
-class ConnextSubscriberListener : public DDSSubscriberListener
+class ConnextSubscriberListener : public DDS::SubscriberListener
 {
 public:
   virtual void on_subscription_matched(

--- a/rmw_connext_cpp/include/rmw_connext_cpp/get_participant.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/get_participant.hpp
@@ -30,7 +30,7 @@ namespace rmw_connext_cpp
  * \return native Connext participant handle if successful, otherwise `NULL`
  */
 RMW_CONNEXT_CPP_PUBLIC
-DDSDomainParticipant *
+DDS::DomainParticipant *
 get_participant(rmw_node_t * node);
 
 }  // namespace rmw_connext_cpp

--- a/rmw_connext_cpp/include/rmw_connext_cpp/get_publisher.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/get_publisher.hpp
@@ -30,7 +30,7 @@ namespace rmw_connext_cpp
  * \return native Connext data writer handle if successful, otherwise `NULL`
  */
 RMW_CONNEXT_CPP_PUBLIC
-DDSDataWriter *
+DDS::DataWriter *
 get_data_writer(rmw_publisher_t * publisher);
 
 }  // namespace rmw_connext_cpp

--- a/rmw_connext_cpp/include/rmw_connext_cpp/get_subscriber.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/get_subscriber.hpp
@@ -30,7 +30,7 @@ namespace rmw_connext_cpp
  * \return native Connext data reader handle if successful, otherwise `NULL`
  */
 RMW_CONNEXT_CPP_PUBLIC
-DDSDataReader *
+DDS::DataReader *
 get_data_reader(rmw_subscription_t * subscription);
 
 }  // namespace rmw_connext_cpp

--- a/rmw_connext_cpp/src/get_participant.cpp
+++ b/rmw_connext_cpp/src/get_participant.cpp
@@ -19,7 +19,7 @@
 namespace rmw_connext_cpp
 {
 
-DDSDomainParticipant *
+DDS::DomainParticipant *
 get_participant(rmw_node_t * node)
 {
   if (!node) {
@@ -28,7 +28,7 @@ get_participant(rmw_node_t * node)
   if (node->implementation_identifier != rti_connext_identifier) {
     return NULL;
   }
-  return static_cast<DDSDomainParticipant *>(node->data);
+  return static_cast<DDS::DomainParticipant *>(node->data);
 }
 
 }  // namespace rmw_connext_cpp

--- a/rmw_connext_cpp/src/get_publisher.cpp
+++ b/rmw_connext_cpp/src/get_publisher.cpp
@@ -20,7 +20,7 @@
 namespace rmw_connext_cpp
 {
 
-DDSDataWriter *
+DDS::DataWriter *
 get_data_writer(rmw_publisher_t * publisher)
 {
   if (!publisher) {

--- a/rmw_connext_cpp/src/get_subscriber.cpp
+++ b/rmw_connext_cpp/src/get_subscriber.cpp
@@ -20,7 +20,7 @@
 namespace rmw_connext_cpp
 {
 
-DDSDataReader *
+DDS::DataReader *
 get_data_reader(rmw_subscription_t * subscription)
 {
   if (!subscription) {

--- a/rmw_connext_cpp/src/process_topic_and_service_names.cpp
+++ b/rmw_connext_cpp/src/process_topic_and_service_names.cpp
@@ -45,7 +45,7 @@ _process_topic_name(
     success = false;
     goto end;
   }
-  *topic_str = DDS_String_dup(concat_str);
+  *topic_str = DDS::String_dup(concat_str);
 
 end:
   if (concat_str) {
@@ -91,8 +91,8 @@ _process_service_name(
     success = false;
     goto end;
   }
-  *request_topic_str = DDS_String_dup(request_concat_str);
-  *response_topic_str = DDS_String_dup(response_concat_str);
+  *request_topic_str = DDS::String_dup(request_concat_str);
+  *response_topic_str = DDS::String_dup(response_concat_str);
 
 end:
   if (request_concat_str) {

--- a/rmw_connext_cpp/src/rmw_client.cpp
+++ b/rmw_connext_cpp/src/rmw_client.cpp
@@ -62,7 +62,7 @@ rmw_create_client(
     RMW_SET_ERROR_MSG("node info handle is null");
     return NULL;
   }
-  auto participant = static_cast<DDSDomainParticipant *>(node_info->participant);
+  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return NULL;
@@ -75,11 +75,11 @@ rmw_create_client(
     return NULL;
   }
   // Past this point, a failure results in unrolling code in the goto fail block.
-  DDS_SubscriberQos subscriber_qos;
-  DDS_ReturnCode_t status;
-  DDS_PublisherQos publisher_qos;
-  DDS_DataReaderQos datareader_qos;
-  DDS_DataWriterQos datawriter_qos;
+  DDS::SubscriberQos subscriber_qos;
+  DDS::ReturnCode_t status;
+  DDS::PublisherQos publisher_qos;
+  DDS::DataReaderQos datareader_qos;
+  DDS::DataWriterQos datawriter_qos;
   DDS::Publisher * dds_publisher = nullptr;
   DDS::Subscriber * dds_subscriber = nullptr;
   DDS::DataReader * response_datareader = nullptr;
@@ -128,9 +128,9 @@ rmw_create_client(
     reinterpret_cast<void **>(&response_datareader),
     reinterpret_cast<void **>(&request_datawriter),
     &rmw_allocate);
-  DDS_String_free(request_topic_str);
+  DDS::String_free(request_topic_str);
   request_topic_str = nullptr;
-  DDS_String_free(response_topic_str);
+  DDS::String_free(response_topic_str);
   response_topic_str = nullptr;
 
   if (!requester) {
@@ -148,14 +148,14 @@ rmw_create_client(
 
   dds_subscriber = response_datareader->get_subscriber();
   status = participant->get_default_subscriber_qos(subscriber_qos);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default subscriber qos");
     goto fail;
   }
 
   dds_publisher = request_datawriter->get_publisher();
   status = participant->get_default_publisher_qos(publisher_qos);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default subscriber qos");
     goto fail;
   }
@@ -167,7 +167,7 @@ rmw_create_client(
   dds_publisher->set_qos(publisher_qos);
 
   read_condition = response_datareader->create_readcondition(
-    DDS_ANY_SAMPLE_STATE, DDS_ANY_VIEW_STATE, DDS_ANY_INSTANCE_STATE);
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   if (!read_condition) {
     RMW_SET_ERROR_MSG("failed to create read condition");
     goto fail;
@@ -228,18 +228,18 @@ rmw_create_client(
   return client;
 fail:
   if (request_topic_str) {
-    DDS_String_free(request_topic_str);
+    DDS::String_free(request_topic_str);
     request_topic_str = nullptr;
   }
   if (response_topic_str) {
-    DDS_String_free(response_topic_str);
+    DDS::String_free(response_topic_str);
     response_topic_str = nullptr;
   }
   if (client) {
     rmw_client_free(client);
   }
   if (response_datareader) {
-    if (participant->delete_datareader(response_datareader) != DDS_RETCODE_OK) {
+    if (participant->delete_datareader(response_datareader) != DDS::RETCODE_OK) {
       std::stringstream ss;
       ss << "leaking datareader while handling failure at " <<
         __FILE__ << ":" << __LINE__ << '\n';
@@ -297,7 +297,7 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
     if (response_datareader) {
       auto read_condition = client_info->read_condition_;
       if (read_condition) {
-        if (response_datareader->delete_readcondition(read_condition) != DDS_RETCODE_OK) {
+        if (response_datareader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
           RMW_SET_ERROR_MSG("failed to delete readcondition");
           result = RMW_RET_ERROR;
         }

--- a/rmw_connext_cpp/src/rmw_compare_gid_equals.cpp
+++ b/rmw_connext_cpp/src/rmw_compare_gid_equals.cpp
@@ -59,7 +59,7 @@ rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * re
   }
   auto matches =
     DDS_InstanceHandle_equals(&detail1->publication_handle, &detail2->publication_handle);
-  *result = (matches == DDS_BOOLEAN_TRUE);
+  *result = (matches == DDS::BOOLEAN_TRUE);
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_connext_cpp/src/rmw_publish.cpp
+++ b/rmw_connext_cpp/src/rmw_publish.cpp
@@ -25,7 +25,7 @@
 #include "connext_static_serialized_dataSupport.h"
 
 bool
-publish(DDSDataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_stream)
+publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_stream)
 {
   ConnextStaticSerializedDataDataWriter * data_writer =
     ConnextStaticSerializedDataDataWriter::narrow(dds_data_writer);
@@ -40,7 +40,7 @@ publish(DDSDataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_strea
     return false;
   }
 
-  DDS_ReturnCode_t status = DDS_RETCODE_ERROR;
+  DDS::ReturnCode_t status = DDS::RETCODE_ERROR;
 
   instance->serialized_data.maximum(0);
   if (cdr_stream->buffer_length > (std::numeric_limits<DDS_Long>::max)()) {
@@ -48,26 +48,26 @@ publish(DDSDataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_strea
     return false;
   }
   if (!instance->serialized_data.loan_contiguous(
-      reinterpret_cast<DDS_Octet *>(cdr_stream->buffer),
-      static_cast<DDS_Long>(cdr_stream->buffer_length),
-      static_cast<DDS_Long>(cdr_stream->buffer_length)))
+      reinterpret_cast<DDS::Octet *>(cdr_stream->buffer),
+      static_cast<DDS::Long>(cdr_stream->buffer_length),
+      static_cast<DDS::Long>(cdr_stream->buffer_length)))
   {
     RMW_SET_ERROR_MSG("failed to loan memory for message");
     goto cleanup;
   }
 
-  status = data_writer->write(*instance, DDS_HANDLE_NIL);
+  status = data_writer->write(*instance, DDS::HANDLE_NIL);
 
 cleanup:
   if (instance) {
     if (!instance->serialized_data.unloan()) {
       fprintf(stderr, "failed to return loaned memory\n");
-      status = DDS_RETCODE_ERROR;
+      status = DDS::RETCODE_ERROR;
     }
     ConnextStaticSerializedDataTypeSupport::delete_data(instance);
   }
 
-  return status == DDS_RETCODE_OK;
+  return status == DDS::RETCODE_OK;
 }
 
 extern "C"
@@ -99,7 +99,7 @@ rmw_publish(const rmw_publisher_t * publisher, const void * ros_message)
     RMW_SET_ERROR_MSG("callbacks handle is null");
     return RMW_RET_ERROR;
   }
-  DDSDataWriter * topic_writer = publisher_info->topic_writer_;
+  DDS::DataWriter * topic_writer = publisher_info->topic_writer_;
   if (!topic_writer) {
     RMW_SET_ERROR_MSG("topic writer handle is null");
     return RMW_RET_ERROR;
@@ -163,7 +163,7 @@ rmw_publish_serialized_message(
     RMW_SET_ERROR_MSG("callbacks handle is null");
     return RMW_RET_ERROR;
   }
-  DDSDataWriter * topic_writer = publisher_info->topic_writer_;
+  DDS::DataWriter * topic_writer = publisher_info->topic_writer_;
   if (!topic_writer) {
     RMW_SET_ERROR_MSG("topic writer handle is null");
     return RMW_RET_ERROR;

--- a/rmw_connext_cpp/src/rmw_service.cpp
+++ b/rmw_connext_cpp/src/rmw_service.cpp
@@ -61,7 +61,7 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("node info handle is null");
     return NULL;
   }
-  auto participant = static_cast<DDSDomainParticipant *>(node_info->participant);
+  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return NULL;
@@ -75,11 +75,11 @@ rmw_create_service(
   }
 
   // Past this point, a failure results in unrolling code in the goto fail block.
-  DDS_DataReaderQos datareader_qos;
-  DDS_DataWriterQos datawriter_qos;
-  DDS_SubscriberQos subscriber_qos;
-  DDS_PublisherQos publisher_qos;
-  DDS_ReturnCode_t status;
+  DDS::DataReaderQos datareader_qos;
+  DDS::DataWriterQos datawriter_qos;
+  DDS::SubscriberQos subscriber_qos;
+  DDS::PublisherQos publisher_qos;
+  DDS::ReturnCode_t status;
   DDS::Publisher * dds_publisher = nullptr;
   DDS::Subscriber * dds_subscriber = nullptr;
   DDS::DataReader * request_datareader = nullptr;
@@ -129,9 +129,9 @@ rmw_create_service(
     reinterpret_cast<void **>(&response_datawriter),
     &rmw_allocate);
 
-  DDS_String_free(request_topic_str);
+  DDS::String_free(request_topic_str);
   request_topic_str = nullptr;
-  DDS_String_free(response_topic_str);
+  DDS::String_free(response_topic_str);
   response_topic_str = nullptr;
 
   if (!replier) {
@@ -148,7 +148,7 @@ rmw_create_service(
   }
 
   read_condition = request_datareader->create_readcondition(
-    DDS_ANY_SAMPLE_STATE, DDS_ANY_VIEW_STATE, DDS_ANY_INSTANCE_STATE);
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   if (!read_condition) {
     RMW_SET_ERROR_MSG("failed to create read condition");
     goto fail;
@@ -156,14 +156,14 @@ rmw_create_service(
 
   dds_subscriber = request_datareader->get_subscriber();
   status = participant->get_default_subscriber_qos(subscriber_qos);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default subscriber qos");
     goto fail;
   }
 
   dds_publisher = response_datawriter->get_publisher();
   status = participant->get_default_publisher_qos(publisher_qos);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default subscriber qos");
     goto fail;
   }
@@ -229,11 +229,11 @@ rmw_create_service(
   return service;
 fail:
   if (request_topic_str) {
-    DDS_String_free(request_topic_str);
+    DDS::String_free(request_topic_str);
     request_topic_str = nullptr;
   }
   if (response_topic_str) {
-    DDS_String_free(response_topic_str);
+    DDS::String_free(response_topic_str);
     response_topic_str = nullptr;
   }
   if (service) {
@@ -241,7 +241,7 @@ fail:
   }
   if (request_datareader) {
     if (read_condition) {
-      if (request_datareader->delete_readcondition(read_condition) != DDS_RETCODE_OK) {
+      if (request_datareader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
         std::stringstream ss;
         ss << "leaking readcondition while handling failure at " <<
           __FILE__ << ":" << __LINE__ << '\n';
@@ -306,7 +306,7 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
     if (request_datareader) {
       auto read_condition = service_info->read_condition_;
       if (read_condition) {
-        if (request_datareader->delete_readcondition(read_condition) != DDS_RETCODE_OK) {
+        if (request_datareader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
           RMW_SET_ERROR_MSG("failed to delete readcondition");
           result = RMW_RET_ERROR;
         }

--- a/rmw_connext_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_connext_cpp/src/rmw_service_server_is_available.cpp
@@ -31,10 +31,9 @@
 rmw_ret_t
 _publisher_count_matched_subscriptions(DDS::DataWriter * datawriter, size_t * count)
 {
-  DDS_ReturnCode_t ret;
-  DDS_PublicationMatchedStatus s;
-  ret = datawriter->get_publication_matched_status(s);
-  if (ret != DDS_RETCODE_OK) {
+  DDS::PublicationMatchedStatus s;
+  DDS::ReturnCode_t ret = datawriter->get_publication_matched_status(s);
+  if (ret != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get publication matched status");
     return RMW_RET_ERROR;
   }
@@ -44,7 +43,7 @@ _publisher_count_matched_subscriptions(DDS::DataWriter * datawriter, size_t * co
   using std::to_string;
   using std::stringstream;
   std::stringstream ss;
-  ss << "DDS_PublicationMatchedStatus:\n" <<
+  ss << "DDS::PublicationMatchedStatus:\n" <<
     "  topic name:               " << datawriter->get_topic()->get_name() << "\n" <<
     "  current_count:            " << to_string(s.current_count) << "\n" <<
     "  current_count_change:     " << to_string(s.current_count_change) << "\n" <<
@@ -62,10 +61,9 @@ _publisher_count_matched_subscriptions(DDS::DataWriter * datawriter, size_t * co
 rmw_ret_t
 _subscription_count_matched_publishers(DDS::DataReader * datareader, size_t * count)
 {
-  DDS_ReturnCode_t ret;
   DDS_SubscriptionMatchedStatus s;
-  ret = datareader->get_subscription_matched_status(s);
-  if (ret != DDS_RETCODE_OK) {
+  DDS::ReturnCode_t ret = datareader->get_subscription_matched_status(s);
+  if (ret != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get subscription matched status");
     return RMW_RET_ERROR;
   }
@@ -74,7 +72,7 @@ _subscription_count_matched_publishers(DDS::DataReader * datareader, size_t * co
   using std::to_string;
   using std::stringstream;
   std::stringstream ss;
-  ss << "DDS_SubscriptionMatchedStatus:\n" <<
+  ss << "DDS::SubscriptionMatchedStatus:\n" <<
     "  topic name:               " << datareader->get_topicdescription()->get_name() << "\n" <<
     "  current_count:            " << to_string(s.current_count) << "\n" <<
     "  current_count_change:     " << to_string(s.current_count_change) << "\n" <<
@@ -157,8 +155,8 @@ rmw_service_server_is_available(
   }
 // TODO(karsten1987): replace this block with logging macros
 #ifdef DISCOVERY_DEBUG_LOGGING
-  DDSPublisher * request_publisher = request_datawriter->get_publisher();
-  DDS_PublisherQos pub_qos;
+  DDS::Publisher * request_publisher = request_datawriter->get_publisher();
+  DDS::PublisherQos pub_qos;
   request_publisher->get_qos(pub_qos);
   fprintf(stderr, "******** rmw_server_is_available *****\n");
   fprintf(stderr, "publisher address %p\n", static_cast<void *>(request_publisher));
@@ -166,8 +164,8 @@ rmw_service_server_is_available(
   DDS::DataReader * response_datareader =
     static_cast<DDS::DataReader *>(callbacks->get_reply_datareader(requester));
   const char * response_topic_name = response_datareader->get_topicdescription()->get_name();
-  DDSSubscriber * response_sub = response_datareader->get_subscriber();
-  DDS_SubscriberQos sub_qos;
+  DDS::Subscriber * response_sub = response_datareader->get_subscriber();
+  DDS::SubscriberQos sub_qos;
   response_sub->get_qos(sub_qos);
   fprintf(stderr, "subscriber address %p\n", static_cast<void *>(response_sub));
   fprintf(stderr, "response topic name: %s\n", response_topic_name);

--- a/rmw_connext_cpp/src/rmw_subscription.cpp
+++ b/rmw_connext_cpp/src/rmw_subscription.cpp
@@ -67,7 +67,7 @@ rmw_create_subscription(
     RMW_SET_ERROR_MSG("node info handle is null");
     return NULL;
   }
-  auto participant = static_cast<DDSDomainParticipant *>(node_info->participant);
+  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return NULL;
@@ -81,15 +81,15 @@ rmw_create_subscription(
   }
   std::string type_name = _create_type_name(callbacks, "msg");
   // Past this point, a failure results in unrolling code in the goto fail block.
-  DDS_TypeCode * type_code = nullptr;
-  DDS_DataReaderQos datareader_qos;
-  DDS_SubscriberQos subscriber_qos;
-  DDS_ReturnCode_t status;
-  DDSSubscriber * dds_subscriber = nullptr;
-  DDSTopic * topic = nullptr;
-  DDSTopicDescription * topic_description = nullptr;
-  DDSDataReader * topic_reader = nullptr;
-  DDSReadCondition * read_condition = nullptr;
+  DDS::TypeCode * type_code = nullptr;
+  DDS::DataReaderQos datareader_qos;
+  DDS::SubscriberQos subscriber_qos;
+  DDS::ReturnCode_t status;
+  DDS::Subscriber * dds_subscriber = nullptr;
+  DDS::Topic * topic = nullptr;
+  DDS::TopicDescription * topic_description = nullptr;
+  DDS::DataReader * topic_reader = nullptr;
+  DDS::ReadCondition * read_condition = nullptr;
   void * info_buf = nullptr;
   void * listener_buf = nullptr;
   ConnextSubscriberListener * subscriber_listener = nullptr;
@@ -119,13 +119,13 @@ rmw_create_subscription(
   // advertise the topic however with a type of the message, e.g. std_msgs::msg::dds_::String
   status = ConnextStaticSerializedDataSupport_register_external_type(
     participant, type_name.c_str(), type_code);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to register external type");
     goto fail;
   }
 
   status = participant->get_default_subscriber_qos(subscriber_qos);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default subscriber qos");
     goto fail;
   }
@@ -150,7 +150,7 @@ rmw_create_subscription(
   listener_buf = nullptr;  // Only free the buffer pointer.
 
   dds_subscriber = participant->create_subscriber(
-    subscriber_qos, subscriber_listener, DDS_SUBSCRIPTION_MATCHED_STATUS);
+    subscriber_qos, subscriber_listener, DDS::SUBSCRIPTION_MATCHED_STATUS);
   if (!dds_subscriber) {
     RMW_SET_ERROR_MSG("failed to create subscriber");
     goto fail;
@@ -158,29 +158,29 @@ rmw_create_subscription(
 
   topic_description = participant->lookup_topicdescription(topic_str);
   if (!topic_description) {
-    DDS_TopicQos default_topic_qos;
+    DDS::TopicQos default_topic_qos;
     status = participant->get_default_topic_qos(default_topic_qos);
-    if (status != DDS_RETCODE_OK) {
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to get default topic qos");
       goto fail;
     }
 
     topic = participant->create_topic(
       topic_str, type_name.c_str(),
-      default_topic_qos, NULL, DDS_STATUS_MASK_NONE);
+      default_topic_qos, NULL, DDS::STATUS_MASK_NONE);
     if (!topic) {
       RMW_SET_ERROR_MSG("failed to create topic");
       goto fail;
     }
   } else {
-    DDS_Duration_t timeout = DDS_Duration_t::from_seconds(0);
+    DDS::Duration_t timeout = DDS::Duration_t::from_seconds(0);
     topic = participant->find_topic(topic_str, timeout);
     if (!topic) {
       RMW_SET_ERROR_MSG("failed to find topic");
       goto fail;
     }
   }
-  DDS_String_free(topic_str);
+  DDS::String_free(topic_str);
   topic_str = nullptr;
 
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
@@ -190,14 +190,14 @@ rmw_create_subscription(
 
   topic_reader = dds_subscriber->create_datareader(
     topic, datareader_qos,
-    NULL, DDS_STATUS_MASK_NONE);
+    NULL, DDS::STATUS_MASK_NONE);
   if (!topic_reader) {
     RMW_SET_ERROR_MSG("failed to create datareader");
     goto fail;
   }
 
   read_condition = topic_reader->create_readcondition(
-    DDS_ANY_SAMPLE_STATE, DDS_ANY_VIEW_STATE, DDS_ANY_INSTANCE_STATE);
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   if (!read_condition) {
     RMW_SET_ERROR_MSG("failed to create read condition");
     goto fail;
@@ -256,7 +256,7 @@ rmw_create_subscription(
   return subscription;
 fail:
   if (topic_str) {
-    DDS_String_free(topic_str);
+    DDS::String_free(topic_str);
     topic_str = nullptr;
   }
   if (subscription) {
@@ -266,21 +266,21 @@ fail:
   if (dds_subscriber) {
     if (topic_reader) {
       if (read_condition) {
-        if (topic_reader->delete_readcondition(read_condition) != DDS_RETCODE_OK) {
+        if (topic_reader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
           std::stringstream ss;
           ss << "leaking readcondition while handling failure at " <<
             __FILE__ << ":" << __LINE__ << '\n';
           (std::cerr << ss.str()).flush();
         }
       }
-      if (dds_subscriber->delete_datareader(topic_reader) != DDS_RETCODE_OK) {
+      if (dds_subscriber->delete_datareader(topic_reader) != DDS::RETCODE_OK) {
         std::stringstream ss;
         ss << "leaking datareader while handling failure at " <<
           __FILE__ << ":" << __LINE__ << '\n';
         (std::cerr << ss.str()).flush();
       }
     }
-    if (participant->delete_subscriber(dds_subscriber) != DDS_RETCODE_OK) {
+    if (participant->delete_subscriber(dds_subscriber) != DDS::RETCODE_OK) {
       std::stringstream ss;
       std::cerr << "leaking subscriber while handling failure at " <<
         __FILE__ << ":" << __LINE__ << '\n';
@@ -368,7 +368,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
     RMW_SET_ERROR_MSG("node info handle is null");
     return RMW_RET_ERROR;
   }
-  auto participant = static_cast<DDSDomainParticipant *>(node_info->participant);
+  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return RMW_RET_ERROR;
@@ -387,13 +387,13 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       if (topic_reader) {
         auto read_condition = subscriber_info->read_condition_;
         if (read_condition) {
-          if (topic_reader->delete_readcondition(read_condition) != DDS_RETCODE_OK) {
+          if (topic_reader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
             RMW_SET_ERROR_MSG("failed to delete readcondition");
             result = RMW_RET_ERROR;
           }
           subscriber_info->read_condition_ = nullptr;
         }
-        if (dds_subscriber->delete_datareader(topic_reader) != DDS_RETCODE_OK) {
+        if (dds_subscriber->delete_datareader(topic_reader) != DDS::RETCODE_OK) {
           RMW_SET_ERROR_MSG("failed to delete datareader");
           result = RMW_RET_ERROR;
         }
@@ -402,7 +402,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
         RMW_SET_ERROR_MSG("cannot delete readcondition because the datareader is null");
         result = RMW_RET_ERROR;
       }
-      if (participant->delete_subscriber(dds_subscriber) != DDS_RETCODE_OK) {
+      if (participant->delete_subscriber(dds_subscriber) != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("failed to delete subscriber");
         result = RMW_RET_ERROR;
       }

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -29,7 +29,7 @@
 
 static bool
 take(
-  DDSDataReader * dds_data_reader,
+  DDS::DataReader * dds_data_reader,
   bool ignore_local_publications,
   rcutils_uint8_array_t * cdr_stream,
   bool * taken,
@@ -56,40 +56,40 @@ take(
   }
 
   ConnextStaticSerializedDataSeq dds_messages;
-  DDS_SampleInfoSeq sample_infos;
+  DDS::SampleInfoSeq sample_infos;
   bool ignore_sample = false;
 
-  DDS_ReturnCode_t status = data_reader->take(
+  DDS::ReturnCode_t status = data_reader->take(
     dds_messages,
     sample_infos,
     1,
-    DDS_ANY_SAMPLE_STATE,
-    DDS_ANY_VIEW_STATE,
-    DDS_ANY_INSTANCE_STATE);
-  if (status == DDS_RETCODE_NO_DATA) {
+    DDS::ANY_SAMPLE_STATE,
+    DDS::ANY_VIEW_STATE,
+    DDS::ANY_INSTANCE_STATE);
+  if (status == DDS::RETCODE_NO_DATA) {
     data_reader->return_loan(dds_messages, sample_infos);
     *taken = false;
     return true;
   }
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("take failed");
     data_reader->return_loan(dds_messages, sample_infos);
     return false;
   }
 
-  DDS_SampleInfo & sample_info = sample_infos[0];
+  DDS::SampleInfo & sample_info = sample_infos[0];
   if (!sample_info.valid_data) {
     // skip sample without data
     ignore_sample = true;
   } else if (ignore_local_publications) {
     // compare the lower 12 octets of the guids from the sender and this receiver
     // if they are equal the sample has been sent from this process and should be ignored
-    DDS_GUID_t sender_guid = sample_info.original_publication_virtual_guid;
-    DDS_InstanceHandle_t receiver_instance_handle = dds_data_reader->get_instance_handle();
+    DDS::GUID_t sender_guid = sample_info.original_publication_virtual_guid;
+    DDS::InstanceHandle_t receiver_instance_handle = dds_data_reader->get_instance_handle();
     ignore_sample = true;
     for (size_t i = 0; i < 12; ++i) {
-      DDS_Octet * sender_element = &(sender_guid.value[i]);
-      DDS_Octet * receiver_element = &(reinterpret_cast<DDS_Octet *>(&receiver_instance_handle)[i]);
+      DDS::Octet * sender_element = &(sender_guid.value[i]);
+      DDS::Octet * receiver_element = &(reinterpret_cast<DDS_Octet *>(&receiver_instance_handle)[i]);
       if (*sender_element != *receiver_element) {
         ignore_sample = false;
         break;
@@ -97,7 +97,7 @@ take(
     }
   }
   if (sample_info.valid_data && sending_publication_handle) {
-    *static_cast<DDS_InstanceHandle_t *>(sending_publication_handle) =
+    *static_cast<DDS::InstanceHandle_t *>(sending_publication_handle) =
       sample_info.publication_handle;
   }
 
@@ -123,7 +123,7 @@ take(
 
   data_reader->return_loan(dds_messages, sample_infos);
 
-  return status == DDS_RETCODE_OK;
+  return status == DDS::RETCODE_OK;
 }
 
 extern "C"
@@ -133,7 +133,7 @@ _take(
   const rmw_subscription_t * subscription,
   void * ros_message,
   bool * taken,
-  DDS_InstanceHandle_t * sending_publication_handle)
+  DDS::InstanceHandle_t * sending_publication_handle)
 {
   if (!subscription) {
     RMW_SET_ERROR_MSG("subscription handle is null");
@@ -159,7 +159,7 @@ _take(
     RMW_SET_ERROR_MSG("subscriber info handle is null");
     return RMW_RET_ERROR;
   }
-  DDSDataReader * topic_reader = subscriber_info->topic_reader_;
+  DDS::DataReader * topic_reader = subscriber_info->topic_reader_;
   if (!topic_reader) {
     RMW_SET_ERROR_MSG("topic reader handle is null");
     return RMW_RET_ERROR;
@@ -209,7 +209,7 @@ rmw_take_with_info(
     RMW_SET_ERROR_MSG("message info is null");
     return RMW_RET_ERROR;
   }
-  DDS_InstanceHandle_t sending_publication_handle;
+  DDS::InstanceHandle_t sending_publication_handle;
   auto ret = _take(subscription, ros_message, taken, &sending_publication_handle);
   if (ret != RMW_RET_OK) {
     // Error string is already set.
@@ -230,7 +230,7 @@ _take_serialized_message(
   const rmw_subscription_t * subscription,
   rmw_serialized_message_t * serialized_message,
   bool * taken,
-  DDS_InstanceHandle_t * sending_publication_handle)
+  DDS::InstanceHandle_t * sending_publication_handle)
 {
   if (!subscription) {
     RMW_SET_ERROR_MSG("subscription handle is null");
@@ -256,7 +256,7 @@ _take_serialized_message(
     RMW_SET_ERROR_MSG("subscriber info handle is null");
     return RMW_RET_ERROR;
   }
-  DDSDataReader * topic_reader = subscriber_info->topic_reader_;
+  DDS::DataReader * topic_reader = subscriber_info->topic_reader_;
   if (!topic_reader) {
     RMW_SET_ERROR_MSG("topic reader handle is null");
     return RMW_RET_ERROR;
@@ -299,7 +299,7 @@ rmw_take_serialized_message_with_info(
     RMW_SET_ERROR_MSG("message info is null");
     return RMW_RET_ERROR;
   }
-  DDS_InstanceHandle_t sending_publication_handle;
+  DDS::InstanceHandle_t sending_publication_handle;
   auto ret =
     _take_serialized_message(subscription, serialized_message, taken, &sending_publication_handle);
   if (ret != RMW_RET_OK) {

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -89,7 +89,8 @@ take(
     ignore_sample = true;
     for (size_t i = 0; i < 12; ++i) {
       DDS::Octet * sender_element = &(sender_guid.value[i]);
-      DDS::Octet * receiver_element = &(reinterpret_cast<DDS_Octet *>(&receiver_instance_handle)[i]);
+      DDS::Octet * receiver_element = 
+	    &(reinterpret_cast<DDS::Octet *>(&receiver_instance_handle)[i]);
       if (*sender_element != *receiver_element) {
         ignore_sample = false;
         break;

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -89,7 +89,7 @@ take(
     ignore_sample = true;
     for (size_t i = 0; i < 12; ++i) {
       DDS::Octet * sender_element = &(sender_guid.value[i]);
-      DDS::Octet * receiver_element = 
+      DDS::Octet * receiver_element =
         &(reinterpret_cast<DDS::Octet *>(&receiver_instance_handle)[i]);
       if (*sender_element != *receiver_element) {
         ignore_sample = false;

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -90,7 +90,7 @@ take(
     for (size_t i = 0; i < 12; ++i) {
       DDS::Octet * sender_element = &(sender_guid.value[i]);
       DDS::Octet * receiver_element = 
-	    &(reinterpret_cast<DDS::Octet *>(&receiver_instance_handle)[i]);
+        &(reinterpret_cast<DDS::Octet *>(&receiver_instance_handle)[i]);
       if (*sender_element != *receiver_element) {
         ignore_sample = false;
         break;

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
@@ -23,7 +23,7 @@
 #  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 # endif
 #endif
-#include <ndds/ndds_cpp.h>
+#include <ndds/ndds_namespace_cpp.h>
 #include <ndds/ndds_requestreply_cpp.h>
 #ifndef _WIN32
 # pragma GCC diagnostic pop

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/qos.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/qos.hpp
@@ -28,16 +28,16 @@
 RMW_CONNEXT_SHARED_CPP_PUBLIC
 bool
 get_datareader_qos(
-  DDSDomainParticipant * participant,
+  DDS::DomainParticipant * participant,
   const rmw_qos_profile_t & qos_profile,
-  DDS_DataReaderQos & datareader_qos);
+  DDS::DataReaderQos & datareader_qos);
 
 RMW_CONNEXT_SHARED_CPP_PUBLIC
 bool
 get_datawriter_qos(
-  DDSDomainParticipant * participant,
+  DDS::DomainParticipant * participant,
   const rmw_qos_profile_t & qos_profile,
-  DDS_DataWriterQos & datawriter_qos);
+  DDS::DataWriterQos & datawriter_qos);
 
 template<typename DDSEntityQos>
 bool
@@ -48,10 +48,10 @@ set_entity_qos_from_profile(
   // Read properties from the rmw profile
   switch (qos_profile.history) {
     case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
-      entity_qos.history.kind = DDS_KEEP_LAST_HISTORY_QOS;
+      entity_qos.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
       break;
     case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
-      entity_qos.history.kind = DDS_KEEP_ALL_HISTORY_QOS;
+      entity_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
       break;
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       break;
@@ -62,10 +62,10 @@ set_entity_qos_from_profile(
 
   switch (qos_profile.reliability) {
     case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
-      entity_qos.reliability.kind = DDS_BEST_EFFORT_RELIABILITY_QOS;
+      entity_qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
       break;
     case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
-      entity_qos.reliability.kind = DDS_RELIABLE_RELIABILITY_QOS;
+      entity_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
       break;
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       break;
@@ -76,10 +76,10 @@ set_entity_qos_from_profile(
 
   switch (qos_profile.durability) {
     case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
-      entity_qos.durability.kind = DDS_TRANSIENT_LOCAL_DURABILITY_QOS;
+      entity_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
       break;
     case RMW_QOS_POLICY_DURABILITY_VOLATILE:
-      entity_qos.durability.kind = DDS_VOLATILE_DURABILITY_QOS;
+      entity_qos.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
       break;
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       break;
@@ -89,7 +89,7 @@ set_entity_qos_from_profile(
   }
 
   if (qos_profile.depth != RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT) {
-    entity_qos.history.depth = static_cast<DDS_Long>(qos_profile.depth);
+    entity_qos.history.depth = static_cast<DDS::Long>(qos_profile.depth);
   }
 
   // ensure the history depth is at least the requested queue size
@@ -98,12 +98,12 @@ set_entity_qos_from_profile(
     entity_qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS &&
     static_cast<size_t>(entity_qos.history.depth) < qos_profile.depth)
   {
-    if (qos_profile.depth > (std::numeric_limits<DDS_Long>::max)()) {
+    if (qos_profile.depth > (std::numeric_limits<DDS::Long>::max)()) {
       RMW_SET_ERROR_MSG(
         "failed to set history depth since the requested queue size exceeds the DDS type");
       return false;
     }
-    entity_qos.history.depth = static_cast<DDS_Long>(qos_profile.depth);
+    entity_qos.history.depth = static_cast<DDS::Long>(qos_profile.depth);
   }
   return true;
 }

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/types.hpp
@@ -36,7 +36,7 @@
 enum EntityType {Publisher, Subscriber};
 
 class CustomDataReaderListener
-  : public DDSDataReaderListener
+  : public DDS::DataReaderListener
 {
 public:
   explicit
@@ -48,27 +48,27 @@ public:
 
   RMW_CONNEXT_SHARED_CPP_PUBLIC
   virtual void add_information(
-    const DDS_GUID_t & participant_guid,
-    const DDS_GUID_t & guid,
+    const DDS::GUID_t & participant_guid,
+    const DDS::GUID_t & guid,
     const std::string & topic_name,
     const std::string & type_name,
     EntityType entity_type);
 
   RMW_CONNEXT_SHARED_CPP_PUBLIC
   virtual void remove_information(
-    const DDS_GUID_t & guid,
+    const DDS::GUID_t & guid,
     EntityType entity_type);
 
   virtual void add_information(
-    const DDS_InstanceHandle_t & participant_instance_handle,
-    const DDS_InstanceHandle_t & instance_handle,
+    const DDS::InstanceHandle_t & participant_instance_handle,
+    const DDS::InstanceHandle_t & instance_handle,
     const std::string & topic_name,
     const std::string & type_name,
     EntityType entity_type);
 
   RMW_CONNEXT_SHARED_CPP_PUBLIC
   virtual void remove_information(
-    const DDS_InstanceHandle_t & instance_handle,
+    const DDS::InstanceHandle_t & instance_handle,
     EntityType entity_type);
 
   RMW_CONNEXT_SHARED_CPP_PUBLIC
@@ -94,7 +94,7 @@ public:
 
 protected:
   std::mutex mutex_;
-  TopicCache<DDS_GUID_t> topic_cache;
+  TopicCache<DDS::GUID_t> topic_cache;
 
 private:
   rmw_guard_condition_t * graph_guard_condition_;
@@ -110,7 +110,7 @@ public:
   : CustomDataReaderListener(implementation_identifier, graph_guard_condition)
   {}
 
-  virtual void on_data_available(DDSDataReader * reader);
+  virtual void on_data_available(DDS::DataReader * reader);
 };
 
 class CustomSubscriberListener
@@ -122,12 +122,12 @@ public:
   : CustomDataReaderListener(implementation_identifier, graph_guard_condition)
   {}
 
-  virtual void on_data_available(DDSDataReader * reader);
+  virtual void on_data_available(DDS::DataReader * reader);
 };
 
 struct ConnextNodeInfo
 {
-  DDSDomainParticipant * participant;
+  DDS::DomainParticipant * participant;
   CustomPublisherListener * publisher_listener;
   CustomSubscriberListener * subscriber_listener;
   rmw_guard_condition_t * graph_guard_condition;
@@ -135,14 +135,14 @@ struct ConnextNodeInfo
 
 struct ConnextPublisherGID
 {
-  DDS_InstanceHandle_t publication_handle;
+  DDS::InstanceHandle_t publication_handle;
 };
 
 struct ConnextWaitSetInfo
 {
-  DDSWaitSet * wait_set;
-  DDSConditionSeq * active_conditions;
-  DDSConditionSeq * attached_conditions;
+  DDS::WaitSet * wait_set;
+  DDS::ConditionSeq * active_conditions;
+  DDS::ConditionSeq * attached_conditions;
 };
 
 #endif  // RMW_CONNEXT_SHARED_CPP__TYPES_HPP_

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
@@ -113,8 +113,8 @@ wait(
     return RMW_RET_ERROR;
   }
 
-  DDSConditionSeq * active_conditions =
-    static_cast<DDSConditionSeq *>(wait_set_info->active_conditions);
+  DDS::ConditionSeq * active_conditions =
+    static_cast<DDS::ConditionSeq *>(wait_set_info->active_conditions);
   if (!active_conditions) {
     RMW_SET_ERROR_MSG("DDS condition sequence handle is null");
     return RMW_RET_ERROR;
@@ -129,7 +129,7 @@ wait(
         RMW_SET_ERROR_MSG("subscriber info handle is null");
         return RMW_RET_ERROR;
       }
-      DDSReadCondition * read_condition = subscriber_info->read_condition_;
+      DDS::ReadCondition * read_condition = subscriber_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;
@@ -145,8 +145,8 @@ wait(
   // add a condition for each guard condition
   if (guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
-      DDSGuardCondition * guard_condition =
-        static_cast<DDSGuardCondition *>(guard_conditions->guard_conditions[i]);
+      DDS::GuardCondition * guard_condition =
+        static_cast<DDS::GuardCondition *>(guard_conditions->guard_conditions[i]);
       if (!guard_condition) {
         RMW_SET_ERROR_MSG("guard condition handle is null");
         return RMW_RET_ERROR;
@@ -170,7 +170,7 @@ wait(
         return RMW_RET_ERROR;
       }
 
-      DDSReadCondition * read_condition = service_info->read_condition_;
+      DDS::ReadCondition * read_condition = service_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;
@@ -193,14 +193,14 @@ wait(
         return RMW_RET_ERROR;
       }
 
-      DDSDataReader * response_datareader = client_info->response_datareader_;
+      DDS::DataReader * response_datareader = client_info->response_datareader_;
       if (!response_datareader) {
         RMW_SET_ERROR_MSG("response datareader handle is null");
         return RMW_RET_ERROR;
       }
 
       // MIGHT BE IMPORTANT !!!
-      DDSReadCondition * read_condition = client_info->read_condition_;
+      DDS::ReadCondition * read_condition = client_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;
@@ -238,7 +238,7 @@ wait(
         RMW_SET_ERROR_MSG("subscriber info handle is null");
         return RMW_RET_ERROR;
       }
-      DDSReadCondition * read_condition = subscriber_info->read_condition_;
+      DDS::ReadCondition * read_condition = subscriber_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;
@@ -267,7 +267,7 @@ wait(
   // set guard condition handles to zero for all not triggered conditions
   if (guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
-      DDSCondition * condition =
+      DDS::Condition * condition =
         static_cast<DDSCondition *>(guard_conditions->guard_conditions[i]);
       if (!condition) {
         RMW_SET_ERROR_MSG("condition handle is null");
@@ -309,7 +309,7 @@ wait(
         RMW_SET_ERROR_MSG("service info handle is null");
         return RMW_RET_ERROR;
       }
-      DDSReadCondition * read_condition = service_info->read_condition_;
+      DDS::ReadCondition * read_condition = service_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;
@@ -344,7 +344,7 @@ wait(
         RMW_SET_ERROR_MSG("client info handle is null");
         return RMW_RET_ERROR;
       }
-      DDSReadCondition * read_condition = client_info->read_condition_;
+      DDS::ReadCondition * read_condition = client_info->read_condition_;
       if (!read_condition) {
         RMW_SET_ERROR_MSG("read condition handle is null");
         return RMW_RET_ERROR;

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
@@ -58,29 +58,29 @@ wait(
         return;
       }
 
-      DDSWaitSet * dds_wait_set = static_cast<DDSWaitSet *>(wait_set_info->wait_set);
+      DDS::WaitSet * dds_wait_set = static_cast<DDS::WaitSet *>(wait_set_info->wait_set);
       if (!dds_wait_set) {
         RMW_SET_ERROR_MSG("DDS wait set handle is null");
         return;
       }
 
-      DDSConditionSeq * attached_conditions =
+      DDS::ConditionSeq * attached_conditions =
         static_cast<DDSConditionSeq *>(wait_set_info->attached_conditions);
       if (!attached_conditions) {
         RMW_SET_ERROR_MSG("DDS condition sequence handle is null");
         return;
       }
 
-      DDS_ReturnCode_t retcode;
+      DDS::ReturnCode_t retcode;
       retcode = dds_wait_set->get_conditions(*attached_conditions);
-      if (retcode != DDS_RETCODE_OK) {
+      if (retcode != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("Failed to get attached conditions for wait set");
         return;
       }
 
-      for (DDS_Long i = 0; i < attached_conditions->length(); ++i) {
+      for (DDS::Long i = 0; i < attached_conditions->length(); ++i) {
         retcode = dds_wait_set->detach_condition((*attached_conditions)[i]);
-        if (retcode != DDS_RETCODE_OK) {
+        if (retcode != DDS::RETCODE_OK) {
           RMW_SET_ERROR_MSG("Failed to get detach condition from wait set");
         }
       }
@@ -107,7 +107,7 @@ wait(
     return RMW_RET_ERROR;
   }
 
-  DDSWaitSet * dds_wait_set = static_cast<DDSWaitSet *>(wait_set_info->wait_set);
+  DDS::WaitSet * dds_wait_set = static_cast<DDS::WaitSet *>(wait_set_info->wait_set);
   if (!dds_wait_set) {
     RMW_SET_ERROR_MSG("DDS wait set handle is null");
     return RMW_RET_ERROR;
@@ -214,17 +214,17 @@ wait(
   }
 
   // invoke wait until one of the conditions triggers
-  DDS_Duration_t timeout;
+  DDS::Duration_t timeout;
   if (!wait_timeout) {
-    timeout = DDS_DURATION_INFINITE;
+    timeout = DDS::DURATION_INFINITE;
   } else {
-    timeout.sec = static_cast<DDS_Long>(wait_timeout->sec);
-    timeout.nanosec = static_cast<DDS_Long>(wait_timeout->nsec);
+    timeout.sec = static_cast<DDS::Long>(wait_timeout->sec);
+    timeout.nanosec = static_cast<DDS::Long>(wait_timeout->nsec);
   }
 
-  DDS_ReturnCode_t status = dds_wait_set->wait(*active_conditions, timeout);
+  DDS::ReturnCode_t status = dds_wait_set->wait(*active_conditions, timeout);
 
-  if (status != DDS_RETCODE_OK && status != DDS_RETCODE_TIMEOUT) {
+  if (status != DDS::RETCODE_OK && status != DDS::RETCODE_TIMEOUT) {
     RMW_SET_ERROR_MSG("failed to wait on wait set");
     return RMW_RET_ERROR;
   }
@@ -245,7 +245,7 @@ wait(
       }
 
       // search for subscriber condition in active set
-      DDS_Long j = 0;
+      DDS::Long j = 0;
       for (; j < active_conditions->length(); ++j) {
         if ((*active_conditions)[j] == read_condition) {
           break;
@@ -256,8 +256,8 @@ wait(
       if (!(j < active_conditions->length())) {
         subscriptions->subscribers[i] = 0;
       }
-      DDS_ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
-      if (retcode != DDS_RETCODE_OK) {
+      DDS::ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
+      if (retcode != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("Failed to get detach condition from wait set");
         return RMW_RET_ERROR;
       }
@@ -275,12 +275,12 @@ wait(
       }
 
       // search for guard condition in active set
-      DDS_Long j = 0;
+      DDS::Long j = 0;
       for (; j < active_conditions->length(); ++j) {
         if ((*active_conditions)[j] == condition) {
-          DDSGuardCondition * guard = static_cast<DDSGuardCondition *>(condition);
-          DDS_ReturnCode_t status = guard->set_trigger_value(DDS_BOOLEAN_FALSE);
-          if (status != DDS_RETCODE_OK) {
+          DDS::GuardCondition * guard = static_cast<DDS::GuardCondition *>(condition);
+          DDS::ReturnCode_t status = guard->set_trigger_value(DDS::BOOLEAN_FALSE);
+          if (status != DDS::RETCODE_OK) {
             RMW_SET_ERROR_MSG("failed to set trigger value");
             return RMW_RET_ERROR;
           }
@@ -292,8 +292,8 @@ wait(
       if (!(j < active_conditions->length())) {
         guard_conditions->guard_conditions[i] = 0;
       }
-      DDS_ReturnCode_t retcode = dds_wait_set->detach_condition(condition);
-      if (retcode != DDS_RETCODE_OK) {
+      DDS::ReturnCode_t retcode = dds_wait_set->detach_condition(condition);
+      if (retcode != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("Failed to get detach condition from wait set");
         return RMW_RET_ERROR;
       }
@@ -316,7 +316,7 @@ wait(
       }
 
       // search for service condition in active set
-      DDS_Long j = 0;
+      DDS::Long j = 0;
       for (; j < active_conditions->length(); ++j) {
         if ((*active_conditions)[j] == read_condition) {
           break;
@@ -327,8 +327,8 @@ wait(
       if (!(j < active_conditions->length())) {
         services->services[i] = 0;
       }
-      DDS_ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
-      if (retcode != DDS_RETCODE_OK) {
+      DDS::ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
+      if (retcode != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("Failed to get detach condition from wait set");
         return RMW_RET_ERROR;
       }
@@ -351,7 +351,7 @@ wait(
       }
 
       // search for service condition in active set
-      DDS_Long j = 0;
+      DDS::Long j = 0;
       for (; j < active_conditions->length(); ++j) {
         if ((*active_conditions)[j] == read_condition) {
           break;
@@ -362,15 +362,15 @@ wait(
       if (!(j < active_conditions->length())) {
         clients->clients[i] = 0;
       }
-      DDS_ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
-      if (retcode != DDS_RETCODE_OK) {
+      DDS::ReturnCode_t retcode = dds_wait_set->detach_condition(read_condition);
+      if (retcode != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("Failed to get detach condition from wait set");
         return RMW_RET_ERROR;
       }
     }
   }
 
-  if (status == DDS_RETCODE_TIMEOUT) {
+  if (status == DDS::RETCODE_TIMEOUT) {
     return RMW_RET_TIMEOUT;
   }
   return RMW_RET_OK;

--- a/rmw_connext_shared_cpp/src/condition_error.cpp
+++ b/rmw_connext_shared_cpp/src/condition_error.cpp
@@ -20,12 +20,12 @@
 rmw_ret_t
 check_attach_condition_error(DDS::ReturnCode_t retcode)
 {
-  if (retcode == DDS_RETCODE_OK) {
+  if (retcode == DDS::RETCODE_OK) {
     return RMW_RET_OK;
   }
-  if (retcode == DDS_RETCODE_OUT_OF_RESOURCES) {
+  if (retcode == DDS::RETCODE_OUT_OF_RESOURCES) {
     RMW_SET_ERROR_MSG("failed to attach condition to wait set: out of resources");
-  } else if (retcode == DDS_RETCODE_BAD_PARAMETER) {
+  } else if (retcode == DDS::RETCODE_BAD_PARAMETER) {
     RMW_SET_ERROR_MSG("failed to attach condition to wait set: condition pointer was invalid");
   } else {
     RMW_SET_ERROR_MSG("failed to attach condition to wait set");

--- a/rmw_connext_shared_cpp/src/guard_condition.cpp
+++ b/rmw_connext_shared_cpp/src/guard_condition.cpp
@@ -65,6 +65,9 @@ destroy_guard_condition(
     return RMW_RET_ERROR)
 
   auto result = RMW_RET_OK;
+#if defined __clang__
+  using DDS::GuardCondition;
+#endif
   RMW_TRY_DESTRUCTOR(
     static_cast<DDS::GuardCondition *>(guard_condition->data)
     ->DDS::GuardCondition::~GuardCondition(),

--- a/rmw_connext_shared_cpp/src/guard_condition.cpp
+++ b/rmw_connext_shared_cpp/src/guard_condition.cpp
@@ -67,7 +67,7 @@ destroy_guard_condition(
   auto result = RMW_RET_OK;
   RMW_TRY_DESTRUCTOR(
     static_cast<DDS::GuardCondition *>(guard_condition->data)
-      ->DDS::GuardCondition::~GuardCondition(),
+    ->DDS::GuardCondition::~GuardCondition(),
     DDS::GuardCondition, result = RMW_RET_ERROR)
   rmw_free(guard_condition->data);
   rmw_guard_condition_free(guard_condition);

--- a/rmw_connext_shared_cpp/src/guard_condition.cpp
+++ b/rmw_connext_shared_cpp/src/guard_condition.cpp
@@ -28,14 +28,14 @@ create_guard_condition(const char * implementation_identifier)
     return NULL;
   }
   // Allocate memory for the DDSGuardCondition object.
-  DDSGuardCondition * dds_guard_condition = nullptr;
-  void * buf = rmw_allocate(sizeof(DDSGuardCondition));
+  DDS::GuardCondition * dds_guard_condition = nullptr;
+  void * buf = rmw_allocate(sizeof(DDS::GuardCondition));
   if (!buf) {
     RMW_SET_ERROR_MSG("failed to allocate memory");
     goto fail;
   }
-  // Use a placement new to construct the DDSGuardCondition in the preallocated buffer.
-  RMW_TRY_PLACEMENT_NEW(dds_guard_condition, buf, goto fail, DDSGuardCondition, )
+  // Use a placement new to construct the DDS::GuardCondition in the preallocated buffer.
+  RMW_TRY_PLACEMENT_NEW(dds_guard_condition, buf, goto fail, DDS::GuardCondition, )
   buf = nullptr;  // Only free the dds_guard_condition pointer; don't need the buf pointer anymore.
   guard_condition->implementation_identifier = implementation_identifier;
   guard_condition->data = dds_guard_condition;
@@ -66,8 +66,8 @@ destroy_guard_condition(
 
   auto result = RMW_RET_OK;
   RMW_TRY_DESTRUCTOR(
-    static_cast<DDSGuardCondition *>(guard_condition->data)->~DDSGuardCondition(),
-    DDSGuardCondition, result = RMW_RET_ERROR)
+    static_cast<DDS::GuardCondition *>(guard_condition->data)->DDS::GuardCondition::~GuardCondition(),
+    DDS::GuardCondition, result = RMW_RET_ERROR)
   rmw_free(guard_condition->data);
   rmw_guard_condition_free(guard_condition);
   return result;

--- a/rmw_connext_shared_cpp/src/guard_condition.cpp
+++ b/rmw_connext_shared_cpp/src/guard_condition.cpp
@@ -66,7 +66,8 @@ destroy_guard_condition(
 
   auto result = RMW_RET_OK;
   RMW_TRY_DESTRUCTOR(
-    static_cast<DDS::GuardCondition *>(guard_condition->data)->DDS::GuardCondition::~GuardCondition(),
+    static_cast<DDS::GuardCondition *>(guard_condition->data)
+      ->DDS::GuardCondition::~GuardCondition(),
     DDS::GuardCondition, result = RMW_RET_ERROR)
   rmw_free(guard_condition->data);
   rmw_guard_condition_free(guard_condition);

--- a/rmw_connext_shared_cpp/src/init.cpp
+++ b/rmw_connext_shared_cpp/src/init.cpp
@@ -20,7 +20,7 @@
 rmw_ret_t
 init()
 {
-  DDSDomainParticipantFactory * dpf_ = DDSDomainParticipantFactory::get_instance();
+  DDS::DomainParticipantFactory * dpf_ = DDS::DomainParticipantFactory::get_instance();
   if (!dpf_) {
     RMW_SET_ERROR_MSG("failed to get participant factory");
     return RMW_RET_ERROR;

--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -37,16 +37,16 @@ create_node(
     RMW_SET_ERROR_MSG("security_options is null");
     return nullptr;
   }
-  DDSDomainParticipantFactory * dpf_ = DDSDomainParticipantFactory::get_instance();
+  DDS::DomainParticipantFactory * dpf_ = DDS::DomainParticipantFactory::get_instance();
   if (!dpf_) {
     RMW_SET_ERROR_MSG("failed to get participant factory");
     return NULL;
   }
 
   // use loopback interface to enable cross vendor communication
-  DDS_DomainParticipantQos participant_qos;
-  DDS_ReturnCode_t status = dpf_->get_default_participant_qos(participant_qos);
-  if (status != DDS_RETCODE_OK) {
+  DDS::DomainParticipantQos participant_qos;
+  DDS::ReturnCode_t status = dpf_->get_default_participant_qos(participant_qos);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default participant qos");
     return NULL;
   }
@@ -57,7 +57,7 @@ create_node(
   // the node name is also set in the user_data
   size_t length = strlen(name) + strlen("name=;") +
     strlen(namespace_) + strlen("namespace=;") + 1;
-  bool success = participant_qos.user_data.value.length(static_cast<DDS_Long>(length));
+  bool success = participant_qos.user_data.value.length(static_cast<DDS::Long>(length));
   if (!success) {
     RMW_SET_ERROR_MSG("failed to resize participant user_data");
     return NULL;
@@ -85,21 +85,21 @@ create_node(
   // forces local traffic to be sent over loopback,
   // even if a more efficient transport (such as shared memory) is installed
   // (in which case traffic will be sent over both transports)
-  status = DDSPropertyQosPolicyHelper::add_property(
+  status = DDS::PropertyQosPolicyHelper::add_property(
     participant_qos.property,
     "dds.transport.UDPv4.builtin.ignore_loopback_interface",
     "0",
-    DDS_BOOLEAN_FALSE);
-  if (status != DDS_RETCODE_OK) {
+    DDS::BOOLEAN_FALSE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to add qos property");
     return NULL;
   }
-  status = DDSPropertyQosPolicyHelper::add_property(
+  status = DDS::PropertyQosPolicyHelper::add_property(
     participant_qos.property,
     "dds.transport.use_510_compatible_locator_kinds",
     "1",
-    DDS_BOOLEAN_FALSE);
-  if (status != DDS_RETCODE_OK) {
+    DDS::BOOLEAN_FALSE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to add qos property");
     return NULL;
   }
@@ -115,11 +115,11 @@ create_node(
   CustomSubscriberListener * subscriber_listener = nullptr;
   void * buf = nullptr;
 
-  DDSDomainParticipant * participant = nullptr;
-  DDSDataReader * data_reader = nullptr;
-  DDSPublicationBuiltinTopicDataDataReader * builtin_publication_datareader = nullptr;
-  DDSSubscriptionBuiltinTopicDataDataReader * builtin_subscription_datareader = nullptr;
-  DDSSubscriber * builtin_subscriber = nullptr;
+  DDS::DomainParticipant * participant = nullptr;
+  DDS::DataReader * data_reader = nullptr;
+  DDS::PublicationBuiltinTopicDataDataReader * builtin_publication_datareader = nullptr;
+  DDS::SubscriptionBuiltinTopicDataDataReader * builtin_subscription_datareader = nullptr;
+  DDS::Subscriber * builtin_subscriber = nullptr;
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
@@ -133,30 +133,30 @@ create_node(
 
   if (security_options->security_root_path) {
     // enable some security stuff
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.load_plugin",
       "com.rti.serv.secure",
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       return NULL;
     }
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.library",
       "nddssecurity",
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       return NULL;
     }
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.create_function",
       "RTI_Security_PluginSuite_create",
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       return NULL;
     }
@@ -194,69 +194,69 @@ create_node(
     }
 
     // now try to pass these filenames to the Authentication plugin
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.authentication.ca_file",
       identity_ca_cert_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.authentication.certificate_file",
       cert_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.authentication.private_key_file",
       key_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
 
     // pass filenames to the Access Control plugin
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.access_control.permissions_authority_file",
       permissions_ca_cert_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
 
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.access_control.governance_file",
       gov_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
 
-    status = DDSPropertyQosPolicyHelper::add_property(
+    status = DDS::PropertyQosPolicyHelper::add_property(
       participant_qos.property,
       "com.rti.serv.secure.access_control.permissions_file",
       perm_fn,
-      DDS_BOOLEAN_FALSE);
-    if (status != DDS_RETCODE_OK) {
+      DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to add security property");
       goto fail;
     }
   }
 
   participant = dpf_->create_participant(
-    static_cast<DDS_DomainId_t>(domain_id), participant_qos, NULL,
-    DDS_STATUS_MASK_NONE);
+    static_cast<DDS::DomainId_t>(domain_id), participant_qos, NULL,
+    DDS::STATUS_MASK_NONE);
   if (!participant) {
     RMW_SET_ERROR_MSG("failed to create participant");
     goto fail;
@@ -269,9 +269,9 @@ create_node(
   }
 
   // setup publisher listener
-  data_reader = builtin_subscriber->lookup_datareader(DDS_PUBLICATION_TOPIC_NAME);
+  data_reader = builtin_subscriber->lookup_datareader(DDS::PUBLICATION_TOPIC_NAME);
   builtin_publication_datareader =
-    static_cast<DDSPublicationBuiltinTopicDataDataReader *>(data_reader);
+    static_cast<DDS::PublicationBuiltinTopicDataDataReader *>(data_reader);
   if (!builtin_publication_datareader) {
     RMW_SET_ERROR_MSG("builtin publication datareader handle is null");
     goto fail;
@@ -292,11 +292,11 @@ create_node(
     publisher_listener, buf, goto fail, CustomPublisherListener,
     implementation_identifier, graph_guard_condition)
   buf = nullptr;
-  builtin_publication_datareader->set_listener(publisher_listener, DDS_DATA_AVAILABLE_STATUS);
+  builtin_publication_datareader->set_listener(publisher_listener, DDS::DATA_AVAILABLE_STATUS);
 
-  data_reader = builtin_subscriber->lookup_datareader(DDS_SUBSCRIPTION_TOPIC_NAME);
+  data_reader = builtin_subscriber->lookup_datareader(DDS::SUBSCRIPTION_TOPIC_NAME);
   builtin_subscription_datareader =
-    static_cast<DDSSubscriptionBuiltinTopicDataDataReader *>(data_reader);
+    static_cast<DDS::SubscriptionBuiltinTopicDataDataReader *>(data_reader);
   if (!builtin_subscription_datareader) {
     RMW_SET_ERROR_MSG("builtin subscription datareader handle is null");
     goto fail;
@@ -312,7 +312,7 @@ create_node(
     subscriber_listener, buf, goto fail, CustomSubscriberListener,
     implementation_identifier, graph_guard_condition)
   buf = nullptr;
-  builtin_subscription_datareader->set_listener(subscriber_listener, DDS_DATA_AVAILABLE_STATUS);
+  builtin_subscription_datareader->set_listener(subscriber_listener, DDS::DATA_AVAILABLE_STATUS);
 
   node_handle = rmw_node_allocate();
   if (!node_handle) {
@@ -355,7 +355,7 @@ create_node(
   return node_handle;
 fail:
   status = dpf_->delete_participant(participant);
-  if (status != DDS_RETCODE_OK) {
+  if (status != DDS::RETCODE_OK) {
     std::stringstream ss;
     ss << "leaking participant while handling failure at " <<
       __FILE__ << ":" << __LINE__;
@@ -419,7 +419,7 @@ destroy_node(const char * implementation_identifier, rmw_node_t * node)
     node->implementation_identifier, implementation_identifier,
     return RMW_RET_ERROR)
 
-  DDSDomainParticipantFactory * dpf_ = DDSDomainParticipantFactory::get_instance();
+  DDS::DomainParticipantFactory * dpf_ = DDS::DomainParticipantFactory::get_instance();
   if (!dpf_) {
     RMW_SET_ERROR_MSG("failed to get participant factory");
     return RMW_RET_ERROR;
@@ -430,7 +430,7 @@ destroy_node(const char * implementation_identifier, rmw_node_t * node)
     RMW_SET_ERROR_MSG("node info handle is null");
     return RMW_RET_ERROR;
   }
-  auto participant = static_cast<DDSDomainParticipant *>(node_info->participant);
+  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
   }
@@ -441,8 +441,8 @@ destroy_node(const char * implementation_identifier, rmw_node_t * node)
     return RMW_RET_ERROR;
   }
 
-  DDS_ReturnCode_t ret = dpf_->delete_participant(participant);
-  if (ret != DDS_RETCODE_OK) {
+  DDS::ReturnCode_t ret = dpf_->delete_participant(participant);
+  if (ret != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to delete participant");
     return RMW_RET_ERROR;
   }

--- a/rmw_connext_shared_cpp/src/node_info_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/node_info_and_types.cpp
@@ -52,7 +52,7 @@
  */
 bool
 __is_node_match(
-  DDS_UserDataQosPolicy & user_data_qos,
+  DDS::UserDataQosPolicy & user_data_qos,
   const char * node_name,
   const char * node_namespace)
 {
@@ -88,28 +88,28 @@ __get_key(
   ConnextNodeInfo * node_info,
   const char * node_name,
   const char * node_namespace,
-  DDS_GUID_t & key)
+  DDS::GUID_t & key)
 {
   auto participant = node_info->participant;
   RMW_CHECK_FOR_NULL_WITH_MSG(participant, "participant handle is null", return RMW_RET_ERROR);
 
-  DDS_DomainParticipantQos dpqos;
+  DDS::DomainParticipantQos dpqos;
   auto dds_ret = participant->get_qos(dpqos);
-  if (dds_ret == DDS_RETCODE_OK && __is_node_match(dpqos.user_data, node_name, node_namespace)) {
+  if (dds_ret == DDS::RETCODE_OK && __is_node_match(dpqos.user_data, node_name, node_namespace)) {
     DDS_InstanceHandle_to_GUID(&key, participant->get_instance_handle());
     return RMW_RET_OK;
   }
 
-  DDS_InstanceHandleSeq handles;
-  if (participant->get_discovered_participants(handles) != DDS_RETCODE_OK) {
+  DDS::InstanceHandleSeq handles;
+  if (participant->get_discovered_participants(handles) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("unable to fetch discovered participants.");
     return RMW_RET_ERROR;
   }
 
-  for (DDS_Long i = 0; i < handles.length(); ++i) {
-    DDS_ParticipantBuiltinTopicData pbtd;
+  for (DDS::Long i = 0; i < handles.length(); ++i) {
+    DDS::ParticipantBuiltinTopicData pbtd;
     auto dds_ret = participant->get_discovered_participant_data(pbtd, handles[i]);
-    if (dds_ret == DDS_RETCODE_OK) {
+    if (dds_ret == DDS::RETCODE_OK) {
       uint8_t * buf = pbtd.user_data.value.get_contiguous_buffer();
       if (buf) {
         std::vector<uint8_t> kv(buf, buf + pbtd.user_data.value.length());
@@ -185,7 +185,7 @@ get_subscriber_names_and_types_by_node(
     return RMW_RET_ERROR;
   }
 
-  DDS_GUID_t key;
+  DDS::GUID_t key;
   auto get_guid_err = __get_key(node_info, node_name, node_namespace, key);
   if (get_guid_err != RMW_RET_OK) {
     return get_guid_err;
@@ -232,7 +232,7 @@ get_publisher_names_and_types_by_node(
     return RMW_RET_ERROR;
   }
 
-  DDS_GUID_t key;
+  DDS::GUID_t key;
   auto get_guid_err = __get_key(node_info, node_name, node_namespace, key);
   if (get_guid_err != RMW_RET_OK) {
     return get_guid_err;
@@ -274,7 +274,7 @@ get_service_names_and_types_by_node(
     return RMW_RET_ERROR;
   }
 
-  DDS_GUID_t key;
+  DDS::GUID_t key;
   auto get_guid_err = __get_key(node_info, node_name, node_namespace, key);
   if (get_guid_err != RMW_RET_OK) {
     return get_guid_err;

--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -46,9 +46,9 @@ get_node_names(
     return RMW_RET_ERROR;
   }
 
-  DDSDomainParticipant * participant = static_cast<ConnextNodeInfo *>(node->data)->participant;
-  DDS_InstanceHandleSeq handles;
-  if (participant->get_discovered_participants(handles) != DDS_RETCODE_OK) {
+  DDS::DomainParticipant * participant = static_cast<ConnextNodeInfo *>(node->data)->participant;
+  DDS::InstanceHandleSeq handles;
+  if (participant->get_discovered_participants(handles) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("unable to fetch discovered participants.");
     return RMW_RET_ERROR;
   }
@@ -65,9 +65,9 @@ get_node_names(
     return rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
   }
 
-  DDS_DomainParticipantQos participant_qos;
-  DDS_ReturnCode_t status = participant->get_qos(participant_qos);
-  if (status != DDS_RETCODE_OK) {
+  DDS::DomainParticipantQos participant_qos;
+  DDS::ReturnCode_t status = participant->get_qos(participant_qos);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default participant qos");
     return RMW_RET_ERROR;
   }
@@ -87,7 +87,7 @@ get_node_names(
     auto dds_ret = participant->get_discovered_participant_data(pbtd, handles[i - 1]);
     std::string name;
     std::string namespace_;
-    if (DDS_RETCODE_OK == dds_ret) {
+    if (DDS::RETCODE_OK == dds_ret) {
       auto data = static_cast<unsigned char *>(pbtd.user_data.value.get_contiguous_buffer());
       std::vector<uint8_t> kv(data, data + pbtd.user_data.value.length());
       auto map = rmw::impl::cpp::parse_key_value(kv);

--- a/rmw_connext_shared_cpp/src/qos.cpp
+++ b/rmw_connext_shared_cpp/src/qos.cpp
@@ -16,32 +16,32 @@
 
 bool
 get_datareader_qos(
-  DDSDomainParticipant * participant,
+  DDS::DomainParticipant * participant,
   const rmw_qos_profile_t & qos_profile,
-  DDS_DataReaderQos & datareader_qos)
+  DDS::DataReaderQos & datareader_qos)
 {
-  DDS_ReturnCode_t status = participant->get_default_datareader_qos(datareader_qos);
-  if (status != DDS_RETCODE_OK) {
+  DDS::ReturnCode_t status = participant->get_default_datareader_qos(datareader_qos);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default datareader qos");
     return false;
   }
 
-  status = DDSPropertyQosPolicyHelper::add_property(
+  status = DDS::PropertyQosPolicyHelper::add_property(
     datareader_qos.property,
     "dds.data_reader.history.memory_manager.fast_pool.pool_buffer_max_size",
     "4096",
-    DDS_BOOLEAN_FALSE);
-  if (status != DDS_RETCODE_OK) {
+    DDS::BOOLEAN_FALSE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to add qos property");
     return false;
   }
 
-  status = DDSPropertyQosPolicyHelper::add_property(
+  status = DDS::PropertyQosPolicyHelper::add_property(
     datareader_qos.property,
     "reader_resource_limits.dynamically_allocate_fragmented_samples",
     "1",
-    DDS_BOOLEAN_FALSE);
-  if (status != DDS_RETCODE_OK) {
+    DDS::BOOLEAN_FALSE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to add qos property");
     return false;
   }
@@ -55,22 +55,22 @@ get_datareader_qos(
 
 bool
 get_datawriter_qos(
-  DDSDomainParticipant * participant,
+  DDS::DomainParticipant * participant,
   const rmw_qos_profile_t & qos_profile,
-  DDS_DataWriterQos & datawriter_qos)
+  DDS::DataWriterQos & datawriter_qos)
 {
-  DDS_ReturnCode_t status = participant->get_default_datawriter_qos(datawriter_qos);
-  if (status != DDS_RETCODE_OK) {
+  DDS::ReturnCode_t status = participant->get_default_datawriter_qos(datawriter_qos);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default datawriter qos");
     return false;
   }
 
-  status = DDSPropertyQosPolicyHelper::add_property(
+  status = DDS::PropertyQosPolicyHelper::add_property(
     datawriter_qos.property,
     "dds.data_writer.history.memory_manager.fast_pool.pool_buffer_max_size",
     "4096",
-    DDS_BOOLEAN_FALSE);
-  if (status != DDS_RETCODE_OK) {
+    DDS::BOOLEAN_FALSE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to add qos property");
     return false;
   }

--- a/rmw_connext_shared_cpp/src/trigger_guard_condition.cpp
+++ b/rmw_connext_shared_cpp/src/trigger_guard_condition.cpp
@@ -34,14 +34,14 @@ trigger_guard_condition(
     guard_condition_handle->implementation_identifier, implementation_identifier,
     return RMW_RET_ERROR)
 
-  DDSGuardCondition * guard_condition =
-    static_cast<DDSGuardCondition *>(guard_condition_handle->data);
+  DDS::GuardCondition * guard_condition =
+    static_cast<DDS::GuardCondition *>(guard_condition_handle->data);
   if (!guard_condition) {
     RMW_SET_ERROR_MSG("guard condition is null");
     return RMW_RET_ERROR;
   }
-  DDS_ReturnCode_t status = guard_condition->set_trigger_value(DDS_BOOLEAN_TRUE);
-  if (status != DDS_RETCODE_OK) {
+  DDS::ReturnCode_t status = guard_condition->set_trigger_value(DDS::BOOLEAN_TRUE);
+  if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to set trigger value");
     return RMW_RET_ERROR;
   }

--- a/rmw_connext_shared_cpp/src/types/custom_data_reader_listener.cpp
+++ b/rmw_connext_shared_cpp/src/types/custom_data_reader_listener.cpp
@@ -30,8 +30,8 @@
 // #define DISCOVERY_DEBUG_LOGGING 1
 
 void CustomDataReaderListener::add_information(
-  const DDS_GUID_t & participant_guid,
-  const DDS_GUID_t & guid,
+  const DDS::GUID_t & participant_guid,
+  const DDS::GUID_t & guid,
   const std::string & topic_name,
   const std::string & type_name,
   EntityType entity_type)
@@ -54,7 +54,7 @@ void CustomDataReaderListener::add_information(
 }
 
 void CustomDataReaderListener::remove_information(
-  const DDS_GUID_t & guid,
+  const DDS::GUID_t & guid,
   EntityType entity_type)
 {
   (void)entity_type;
@@ -72,23 +72,23 @@ void CustomDataReaderListener::remove_information(
 }
 
 void CustomDataReaderListener::add_information(
-  const DDS_InstanceHandle_t & participant_instance_handle,
-  const DDS_InstanceHandle_t & instance_handle,
+  const DDS::InstanceHandle_t & participant_instance_handle,
+  const DDS::InstanceHandle_t & instance_handle,
   const std::string & topic_name,
   const std::string & type_name,
   EntityType entity_type)
 {
-  DDS_GUID_t guid, participant_guid;
+  DDS::GUID_t guid, participant_guid;
   DDS_InstanceHandle_to_GUID(&guid, instance_handle);
   DDS_InstanceHandle_to_GUID(&participant_guid, participant_instance_handle);
   add_information(participant_guid, guid, topic_name, type_name, entity_type);
 }
 
 void CustomDataReaderListener::remove_information(
-  const DDS_InstanceHandle_t & instance_handle,
+  const DDS::InstanceHandle_t & instance_handle,
   EntityType entity_type)
 {
-  DDS_GUID_t guid;
+  DDS::GUID_t guid;
   DDS_InstanceHandle_to_GUID(&guid, instance_handle);
   remove_information(guid, entity_type);
 }
@@ -152,7 +152,7 @@ CustomDataReaderListener::fill_service_names_and_types(
 void CustomDataReaderListener::fill_topic_names_and_types_by_guid(
   bool no_demangle,
   std::map<std::string, std::set<std::string>> & topic_names_to_types_by_guid,
-  DDS_GUID_t & participant_guid)
+  DDS::GUID_t & participant_guid)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   const auto & map = topic_cache.get_topic_types_by_guid(participant_guid);
@@ -174,7 +174,7 @@ void CustomDataReaderListener::fill_topic_names_and_types_by_guid(
 
 void CustomDataReaderListener::fill_service_names_and_types_by_guid(
   std::map<std::string, std::set<std::string>> & services,
-  DDS_GUID_t & participant_guid)
+  DDS::GUID_t & participant_guid)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   const auto & map = topic_cache.get_topic_types_by_guid(participant_guid);

--- a/rmw_connext_shared_cpp/src/types/custom_publisher_listener.cpp
+++ b/rmw_connext_shared_cpp/src/types/custom_publisher_listener.cpp
@@ -20,18 +20,18 @@
 // Uncomment this to get extra console output about discovery.
 // #define DISCOVERY_DEBUG_LOGGING 1
 
-void CustomPublisherListener::on_data_available(DDSDataReader * reader)
+void CustomPublisherListener::on_data_available(DDS::DataReader * reader)
 {
-  DDSPublicationBuiltinTopicDataDataReader * builtin_reader =
-    static_cast<DDSPublicationBuiltinTopicDataDataReader *>(reader);
+  DDS::PublicationBuiltinTopicDataDataReader * builtin_reader =
+    static_cast<DDS::PublicationBuiltinTopicDataDataReader *>(reader);
 
-  DDS_PublicationBuiltinTopicDataSeq data_seq;
-  DDS_SampleInfoSeq info_seq;
-  DDS_ReturnCode_t retcode = builtin_reader->take(
-    data_seq, info_seq, DDS_LENGTH_UNLIMITED,
-    DDS_ANY_SAMPLE_STATE, DDS_ANY_VIEW_STATE, DDS_ANY_INSTANCE_STATE);
+  DDS::PublicationBuiltinTopicDataSeq data_seq;
+  DDS::SampleInfoSeq info_seq;
+  DDS::ReturnCode_t retcode = builtin_reader->take(
+    data_seq, info_seq, DDS::LENGTH_UNLIMITED,
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
-  if (retcode == DDS_RETCODE_NO_DATA) {
+  if (retcode == DDS::RETCODE_NO_DATA) {
     return;
   }
   if (retcode != DDS_RETCODE_OK) {
@@ -40,12 +40,12 @@ void CustomPublisherListener::on_data_available(DDSDataReader * reader)
   }
 
   for (auto i = 0; i < data_seq.length(); ++i) {
-    DDS_GUID_t guid;
+    DDS::GUID_t guid;
     DDS_InstanceHandle_to_GUID(&guid, info_seq[i].instance_handle);
     if (info_seq[i].valid_data &&
-      info_seq[i].instance_state == DDS_ALIVE_INSTANCE_STATE)
+      info_seq[i].instance_state == DDS::ALIVE_INSTANCE_STATE)
     {
-      DDS_GUID_t participant_guid;
+      DDS::GUID_t participant_guid;
       DDS_BuiltinTopicKey_to_GUID(&participant_guid, data_seq[i].participant_key);
       add_information(
         participant_guid,

--- a/rmw_connext_shared_cpp/src/types/custom_subscriber_listener.cpp
+++ b/rmw_connext_shared_cpp/src/types/custom_subscriber_listener.cpp
@@ -17,33 +17,33 @@
 #include "rmw_connext_shared_cpp/guid_helper.hpp"
 #include "rmw_connext_shared_cpp/types.hpp"
 
-void CustomSubscriberListener::on_data_available(DDSDataReader * reader)
+void CustomSubscriberListener::on_data_available(DDS::DataReader * reader)
 {
-  DDSSubscriptionBuiltinTopicDataDataReader * builtin_reader =
-    static_cast<DDSSubscriptionBuiltinTopicDataDataReader *>(reader);
+  DDS::SubscriptionBuiltinTopicDataDataReader * builtin_reader =
+    static_cast<DDS::SubscriptionBuiltinTopicDataDataReader *>(reader);
 
-  DDS_SubscriptionBuiltinTopicDataSeq data_seq;
-  DDS_SampleInfoSeq info_seq;
-  DDS_ReturnCode_t retcode = builtin_reader->take(
-    data_seq, info_seq, DDS_LENGTH_UNLIMITED,
-    DDS_ANY_SAMPLE_STATE, DDS_ANY_VIEW_STATE, DDS_ANY_INSTANCE_STATE);
+  DDS::SubscriptionBuiltinTopicDataSeq data_seq;
+  DDS::SampleInfoSeq info_seq;
+  DDS::ReturnCode_t retcode = builtin_reader->take(
+    data_seq, info_seq, DDS::LENGTH_UNLIMITED,
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
-  if (retcode == DDS_RETCODE_NO_DATA) {
+  if (retcode == DDS::RETCODE_NO_DATA) {
     return;
   }
-  if (retcode != DDS_RETCODE_OK) {
+  if (retcode != DDS::RETCODE_OK) {
     fprintf(stderr, "failed to access data from the built-in reader\n");
     return;
   }
 
   for (auto i = 0; i < data_seq.length(); ++i) {
-    DDS_GUID_t guid;
+    DDS::GUID_t guid;
 
     DDS_InstanceHandle_to_GUID(&guid, info_seq[i].instance_handle);
     if (info_seq[i].valid_data &&
-      info_seq[i].instance_state == DDS_ALIVE_INSTANCE_STATE)
+      info_seq[i].instance_state == DDS::ALIVE_INSTANCE_STATE)
     {
-      DDS_GUID_t participant_guid;
+      DDS::GUID_t participant_guid;
       DDS_BuiltinTopicKey_to_GUID(&participant_guid, data_seq[i].participant_key);
       add_information(
         participant_guid,

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -98,7 +98,7 @@ fail:
     }
     if (wait_set_info->wait_set) {
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-		    wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
+        wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
       rmw_free(wait_set_info->wait_set);
     }
     wait_set_info = nullptr;
@@ -131,18 +131,18 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
   if (wait_set_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
       wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
-	    result = RMW_RET_ERROR)
+      result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
       wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
-	    result = RMW_RET_ERROR)
+      result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }
   if (wait_set_info->wait_set) {
     RMW_TRY_DESTRUCTOR(
-	    wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
+      wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->wait_set);
   }
   wait_set_info = nullptr;

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -130,13 +130,13 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
   // Explicitly call destructor since the "placement new" was used
   if (wait_set_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
+      wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq,
       result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
+      wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq,
       result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -97,7 +97,8 @@ fail:
       rmw_free(wait_set_info->attached_conditions);
     }
     if (wait_set_info->wait_set) {
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+		wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
       rmw_free(wait_set_info->wait_set);
     }
     wait_set_info = nullptr;
@@ -129,16 +130,19 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
   // Explicitly call destructor since the "placement new" was used
   if (wait_set_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
+	  result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
+	  result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }
   if (wait_set_info->wait_set) {
-    RMW_TRY_DESTRUCTOR(wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
+    RMW_TRY_DESTRUCTOR(
+	  wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->wait_set);
   }
   wait_set_info = nullptr;

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -35,25 +35,25 @@ create_wait_set(const char * implementation_identifier, size_t max_conditions)
     goto fail;
   }
 
-  wait_set_info->wait_set = static_cast<DDSWaitSet *>(rmw_allocate(sizeof(DDSWaitSet)));
+  wait_set_info->wait_set = static_cast<DDS::WaitSet *>(rmw_allocate(sizeof(DDS::WaitSet)));
   if (!wait_set_info->wait_set) {
     RMW_SET_ERROR_MSG("failed to allocate wait set");
     goto fail;
   }
 
   RMW_TRY_PLACEMENT_NEW(
-    wait_set_info->wait_set, wait_set_info->wait_set, goto fail, DDSWaitSet, )
+    wait_set_info->wait_set, wait_set_info->wait_set, goto fail, DDS::WaitSet, )
 
   // Now allocate storage for the ConditionSeq objects
   wait_set_info->active_conditions =
-    static_cast<DDSConditionSeq *>(rmw_allocate(sizeof(DDSConditionSeq)));
+    static_cast<DDS::ConditionSeq *>(rmw_allocate(sizeof(DDS::ConditionSeq)));
   if (!wait_set_info->active_conditions) {
     RMW_SET_ERROR_MSG("failed to allocate active_conditions sequence");
     goto fail;
   }
 
   wait_set_info->attached_conditions =
-    static_cast<DDSConditionSeq *>(rmw_allocate(sizeof(DDSConditionSeq)));
+    static_cast<DDS::ConditionSeq *>(rmw_allocate(sizeof(DDS::ConditionSeq)));
   if (!wait_set_info->attached_conditions) {
     RMW_SET_ERROR_MSG("failed to allocate attached_conditions sequence");
     goto fail;
@@ -63,22 +63,22 @@ create_wait_set(const char * implementation_identifier, size_t max_conditions)
   if (max_conditions > 0) {
     RMW_TRY_PLACEMENT_NEW(
       wait_set_info->active_conditions, wait_set_info->active_conditions, goto fail,
-      DDSConditionSeq, static_cast<DDS_Long>(max_conditions))
+      DDS::ConditionSeq, static_cast<DDS::Long>(max_conditions))
 
     RMW_TRY_PLACEMENT_NEW(
       wait_set_info->attached_conditions, wait_set_info->attached_conditions, goto fail,
-      DDSConditionSeq,
-      static_cast<DDS_Long>(max_conditions))
+      DDS::ConditionSeq,
+      static_cast<DDS::Long>(max_conditions))
   } else {
     // Else, don't preallocate: the vectors will size dynamically when rmw_wait is called.
     // Default-construct the ConditionSeqs.
     RMW_TRY_PLACEMENT_NEW(
       wait_set_info->active_conditions, wait_set_info->active_conditions,
-      goto fail, DDSConditionSeq, )
+      goto fail, DDS::ConditionSeq, )
 
     RMW_TRY_PLACEMENT_NEW(
       wait_set_info->attached_conditions, wait_set_info->attached_conditions, goto fail,
-      DDSConditionSeq, )
+      DDS::ConditionSeq, )
   }
 
   return wait_set;
@@ -88,16 +88,16 @@ fail:
     if (wait_set_info->active_conditions) {
       // How to know which constructor threw?
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        wait_set_info->active_conditions->~DDSConditionSeq(), DDSConditionSeq)
+        wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), DDS::ConditionSeq)
       rmw_free(wait_set_info->active_conditions);
     }
     if (wait_set_info->attached_conditions) {
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        wait_set_info->attached_conditions->~DDSConditionSeq(), DDSConditionSeq)
+        wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), DDS::ConditionSeq)
       rmw_free(wait_set_info->attached_conditions);
     }
     if (wait_set_info->wait_set) {
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(wait_set_info->wait_set->~DDSWaitSet(), DDSWaitSet)
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
       rmw_free(wait_set_info->wait_set);
     }
     wait_set_info = nullptr;
@@ -129,16 +129,16 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
   // Explicitly call destructor since the "placement new" was used
   if (wait_set_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->active_conditions->~DDSConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
-      wait_set_info->attached_conditions->~DDSConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
+      wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }
   if (wait_set_info->wait_set) {
-    RMW_TRY_DESTRUCTOR(wait_set_info->wait_set->~DDSWaitSet(), WaitSet, result = RMW_RET_ERROR)
+    RMW_TRY_DESTRUCTOR(wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->wait_set);
   }
   wait_set_info = nullptr;

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -98,7 +98,7 @@ fail:
     }
     if (wait_set_info->wait_set) {
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-		wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
+		    wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
       rmw_free(wait_set_info->wait_set);
     }
     wait_set_info = nullptr;
@@ -131,18 +131,18 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
   if (wait_set_info->active_conditions) {
     RMW_TRY_DESTRUCTOR(
       wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
-	  result = RMW_RET_ERROR)
+	    result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
     RMW_TRY_DESTRUCTOR(
       wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq, 
-	  result = RMW_RET_ERROR)
+	    result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }
   if (wait_set_info->wait_set) {
     RMW_TRY_DESTRUCTOR(
-	  wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
+	    wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->wait_set);
   }
   wait_set_info = nullptr;

--- a/rmw_connext_shared_cpp/src/wait_set.cpp
+++ b/rmw_connext_shared_cpp/src/wait_set.cpp
@@ -87,16 +87,25 @@ fail:
   if (wait_set_info) {
     if (wait_set_info->active_conditions) {
       // How to know which constructor threw?
+#if defined __clang__
+      using DDS::ConditionSeq;
+#endif
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
         wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), DDS::ConditionSeq)
       rmw_free(wait_set_info->active_conditions);
     }
     if (wait_set_info->attached_conditions) {
+#if defined __clang__
+      using DDS::ConditionSeq;
+#endif
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
         wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), DDS::ConditionSeq)
       rmw_free(wait_set_info->attached_conditions);
     }
     if (wait_set_info->wait_set) {
+#if defined __clang__
+      using DDS::WaitSet;
+#endif
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
         wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), DDS::WaitSet)
       rmw_free(wait_set_info->wait_set);
@@ -129,18 +138,27 @@ destroy_wait_set(const char * implementation_identifier, rmw_wait_set_t * wait_s
 
   // Explicitly call destructor since the "placement new" was used
   if (wait_set_info->active_conditions) {
+#if defined __clang__
+    using DDS::ConditionSeq;
+#endif
     RMW_TRY_DESTRUCTOR(
       wait_set_info->active_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq,
       result = RMW_RET_ERROR)
     rmw_free(wait_set_info->active_conditions);
   }
   if (wait_set_info->attached_conditions) {
+#if defined __clang__
+    using DDS::ConditionSeq;
+#endif
     RMW_TRY_DESTRUCTOR(
       wait_set_info->attached_conditions->DDS::ConditionSeq::~ConditionSeq(), ConditionSeq,
       result = RMW_RET_ERROR)
     rmw_free(wait_set_info->attached_conditions);
   }
   if (wait_set_info->wait_set) {
+#if defined __clang__
+    using DDS::WaitSet;
+#endif
     RMW_TRY_DESTRUCTOR(
       wait_set_info->wait_set->DDS::WaitSet::~WaitSet(), WaitSet, result = RMW_RET_ERROR)
     rmw_free(wait_set_info->wait_set);


### PR DESCRIPTION
This PR includes the other PRs made last week. Instead of using the DDS_ prefixed versions in the global namespace we are now using the DDS namespace, this simplifies porting and maintaining code between the various rmw_ implementations, see #323 