### PR TITLE
Include rmw/macros.hpp

### DIFF
--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
@@ -19,6 +19,7 @@
 
 #include "rmw/error_handling.h"
 #include "rmw/impl/cpp/macros.hpp"
+#include "rmw/macros.hpp"
 #include "rmw/types.h"
 
 #include "rmw_connext_shared_cpp/condition_error.hpp"


### PR DESCRIPTION
Fix cppcheck complaint about `RMW_CHECK_IDENTIFIERS_MATCH`

https://ci.ros2.org/job/nightly_osx_debug/1175/testReport/junit/rmw_connext_shared_cpp/cppcheck/error__unknownMacro___Users_osrf_jenkins_agent_workspace_nightly_osx_debug_ws_src_ros2_rmw_connext_rmw_connext_shared_cpp_include_rmw_connext_shared_cpp_wait_hpp_51_/

CI [![Build Status](https://ci.ros2.org/job/ci_osx/5179/badge/icon)](https://ci.ros2.org/job/ci_osx/5179/)