### PR TITLE
Add rmw includes to cppcheck

### DIFF
--- a/rmw_connext_shared_cpp/CMakeLists.txt
+++ b/rmw_connext_shared_cpp/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rmw_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
 endif()
 


### PR DESCRIPTION
Fix cppcheck error complaining about unknown macro (context https://github.com/ament/ament_lint/pull/117#discussion_r261690823)