### PR TITLE
update patches for Connext 6, ignore pedantic warning

### DIFF
--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_data.h.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_data.h.patch
@@ -7,5 +7,5 @@
 -#include "ndds/ndds_cpp.h"
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
+ #include "rti/xcdr/Interpreter.hpp"
  #else
- #include "ndds_standalone_type.h"

--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.cxx.patch
@@ -2,12 +2,12 @@
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.cxx
 @@ -11,7 +11,7 @@ or consult the RTI Connext manual.
  #include <string.h>
-
+ 
  #ifndef ndds_cpp_h
 -#include "ndds/ndds_cpp.h"
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
-
+ 
  #ifndef osapi_type_h
 @@ -379,74 +379,81 @@ ConnextStaticSerializedDataPlugin_serialize(
      RTIBool serialize_sample,

--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.h.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.h.patch
@@ -1,6 +1,6 @@
 --- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
-@@ -324,6 +324,9 @@ extern "C" {
+@@ -258,6 +258,9 @@ extern "C" {
      NDDSUSERDllExport extern struct PRESTypePlugin*
      ConnextStaticSerializedDataPlugin_new(void);
  

--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataSupport.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataSupport.cxx.patch
@@ -1,6 +1,6 @@
 --- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
-@@ -115,3 +115,62 @@ Defines:   TTypeSupport, TData, TDataReader, TDataWriter
+@@ -123,3 +123,62 @@ Defines:   TTypeSupport, TData, TDataReader, TDataWriter
  #undef TPlugin_new
  #undef TPlugin_delete
 

--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataSupport.h.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataSupport.h.patch
@@ -8,7 +8,7 @@
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
  
- #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE) || defined(RTI_INTIME)) && defined(NDDS_USER_DLL_EXPORT)
 @@ -44,13 +44,106 @@ implementing generics in C and C++.
  
  #endif
@@ -106,8 +106,12 @@
 +  ConnextStaticSerializedDataTypeSupport();
 +};
  
- DDS_DATAWRITER_CPP(ConnextStaticSerializedDataDataWriter, ConnextStaticSerializedData);
- DDS_DATAREADER_CPP(ConnextStaticSerializedDataDataReader, ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
+ #define ENABLE_TDATAWRITER_DATA_CONSTRUCTOR_METHODS
+ DDS_DATAWRITER_WITH_DATA_CONSTRUCTOR_METHODS_CPP(ConnextStaticSerializedDataDataWriter, ConnextStaticSerializedData);
+ #undef ENABLE_TDATAWRITER_DATA_CONSTRUCTOR_METHODS
+ #define ENABLE_TDATAREADER_DATA_CONSISTENCY_CHECK_METHOD
+ DDS_DATAREADER_W_DATA_CONSISTENCY_CHECK(ConnextStaticSerializedDataDataReader, ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
+ #undef ENABLE_TDATAREADER_DATA_CONSISTENCY_CHECK_METHOD
  
 +NDDSUSERDllExport
 +DDS_ReturnCode_t
@@ -116,6 +120,6 @@
 +  const char * type_name,
 +  struct DDS_TypeCode * type_code);
 +
- #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE) || defined(RTI_INTIME)) && defined(NDDS_USER_DLL_EXPORT)
  /* If the code is building on Windows, stop exporting symbols.
  */

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
@@ -17,6 +17,7 @@
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"


### PR DESCRIPTION
I updated the trivial parts of the patches to apply to the code generated by Connext 6. The patch file `connext_static_serialized_dataPlugin.cxx.patch` contains the heavy lifting and still needs to be updated.

@Karsten1987 since you wrote these patches can you please take a look and add commits to this branch to make this work with Connext 6. The goal is to just make this work with the latest release of Connext - not change the way this is being done.

(It seems that the current logic applying the patches doesn't check if they apply cleanly and applies them anyway. So instead of failing when trying it with Connext 6 the patch files are applied even though the context doesn't match the actual files. Then it fails to compile the patched code since the content of the patched files doesn't make any sense. It would be nice if the logic which actually check that the patches apply cleanly - but that doesn't have to be par of this PR.)