### PR TITLE
Add missing get_serialized_message_size method.

### DIFF
--- a/rmw_connext_cpp/src/rmw_serialize.cpp
+++ b/rmw_connext_cpp/src/rmw_serialize.cpp
@@ -68,4 +68,14 @@ rmw_deserialize(
 
   return RMW_RET_OK;
 }
+
+rmw_ret_t
+rmw_get_serialized_message_size(
+  const rosidl_message_type_support_t * /*type_support*/,
+  const rosidl_message_bounds_t * /*message_bounds*/,
+  size_t * /*size*/)
+{
+  RMW_SET_ERROR_MSG("unimplemented");
+  return RMW_RET_ERROR;
+}
 }  // extern "C"


### PR DESCRIPTION
Addresses errors seen by @clalancette Windows Debug CI running tests for `rcl`

```
01:26:57.428 10:   'failed to resolve symbol 'rmw_get_serialized_message_size' in shared library 'C:\J\workspace\ci_windows\ws\install\bin/rmw_connext_cpp.dll', at C:\J\workspace\ci_windows\ws\src\ros2\rmw_implementation\rmw_implementation\src\functions.cpp:163
```

This should have been included in #353 for the addition of preallocation stubs, but was overlooked.

Signed-off-by: Michael Carroll <michael@openrobotics.org>