### PR TITLE
get_actual_qos() is not setting all of rmw_qos_profile_t

### DIFF
--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -392,10 +392,10 @@ rmw_publisher_get_actual_qos(
   }
 
   switch (dds_qos.history.kind) {
-    case DDS::KEEP_LAST_HISTORY_QOS:
+    case DDS_KEEP_LAST_HISTORY_QOS:
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
       break;
-    case DDS::KEEP_ALL_HISTORY_QOS:
+    case DDS_KEEP_ALL_HISTORY_QOS:
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
       break;
     default:
@@ -405,10 +405,10 @@ rmw_publisher_get_actual_qos(
   qos->depth = static_cast<size_t>(dds_qos.history.depth);
 
   switch (dds_qos.reliability.kind) {
-    case DDS::BEST_EFFORT_RELIABILITY_QOS:
+    case DDS_BEST_EFFORT_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
       break;
-    case DDS::RELIABLE_RELIABILITY_QOS:
+    case DDS_RELIABLE_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
       break;
     default:
@@ -417,10 +417,10 @@ rmw_publisher_get_actual_qos(
   }
 
   switch (dds_qos.durability.kind) {
-    case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
+    case DDS_TRANSIENT_LOCAL_DURABILITY_QOS:
       qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
       break;
-    case DDS::VOLATILE_DURABILITY_QOS:
+    case DDS_VOLATILE_DURABILITY_QOS:
       qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
       break;
     default:
@@ -435,13 +435,13 @@ rmw_publisher_get_actual_qos(
   qos->lifespan.nsec = dds_qos.lifespan.duration.nanosec;
 
   switch (dds_qos.liveliness.kind) {
-    case DDS::AUTOMATIC_LIVELINESS_QOS:
+    case DDS_AUTOMATIC_LIVELINESS_QOS:
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
       break;
-    case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
+    case DDS_MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
       break;
-    case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
+    case DDS_MANUAL_BY_TOPIC_LIVELINESS_QOS:
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
       break;
     default:

--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -390,40 +390,66 @@ rmw_publisher_get_actual_qos(
     RMW_SET_ERROR_MSG("publisher internal dds publisher is invalid");
     return RMW_RET_ERROR;
   }
+
   switch (dds_qos.history.kind) {
-    case DDS_KEEP_LAST_HISTORY_QOS:
+    case DDS::KEEP_LAST_HISTORY_QOS:
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
       break;
-    case DDS_KEEP_ALL_HISTORY_QOS:
+    case DDS::KEEP_ALL_HISTORY_QOS:
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
       break;
     default:
       qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
       break;
   }
-  switch (dds_qos.durability.kind) {
-    case DDS_TRANSIENT_LOCAL_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-      break;
-    case DDS_VOLATILE_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-      break;
-    default:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
-      break;
-  }
+  qos->depth = static_cast<size_t>(dds_qos.history.depth);
+
   switch (dds_qos.reliability.kind) {
-    case DDS_BEST_EFFORT_RELIABILITY_QOS:
+    case DDS::BEST_EFFORT_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
       break;
-    case DDS_RELIABLE_RELIABILITY_QOS:
+    case DDS::RELIABLE_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
       break;
     default:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
       break;
   }
-  qos->depth = static_cast<size_t>(dds_qos.history.depth);
+
+  switch (dds_qos.durability.kind) {
+    case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+      break;
+    case DDS::VOLATILE_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+      break;
+    default:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+      break;
+  }
+
+  qos->deadline.sec = dds_qos.deadline.period.sec;
+  qos->deadline.nsec = dds_qos.deadline.period.nanosec;
+
+  qos->lifespan.sec = dds_qos.lifespan.duration.sec;
+  qos->lifespan.nsec = dds_qos.lifespan.duration.nanosec;
+
+  switch (dds_qos.liveliness.kind) {
+    case DDS::AUTOMATIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+      break;
+    case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
+      break;
+    case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+      break;
+    default:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+      break;
+  }
+  qos->liveliness_lease_duration.sec = dds_qos.liveliness.lease_duration.sec;
+  qos->liveliness_lease_duration.nsec = dds_qos.liveliness.lease_duration.nanosec;
 
   return RMW_RET_OK;
 }


### PR DESCRIPTION
The current implementation of `get_actual_qos()` is not setting/output the values for lifespan, deadline, and liveliness QoS policies.

Depends on https://github.com/ros2/rmw/pull/175.