### PR TITLE
speed up copy with memcpy

### DIFF
--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -116,9 +116,8 @@ take(
       *taken = false;
       return false;
     }
-    for (unsigned int i = 0; i < static_cast<unsigned int>(cdr_stream->buffer_length); ++i) {
-      cdr_stream->buffer[i] = dds_messages[0].serialized_data[i];
-    }
+    memcpy(cdr_stream->buffer, &dds_messages[0].serialized_data[0], cdr_stream->buffer_length);
+    
     *taken = true;
   } else {
     *taken = false;

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -117,7 +117,7 @@ take(
       return false;
     }
     memcpy(cdr_stream->buffer, &dds_messages[0].serialized_data[0], cdr_stream->buffer_length);
-    
+
     *taken = true;
   } else {
     *taken = false;


### PR DESCRIPTION
Replace the byte-wise copy loop with a call to memcpy.
While not a complete fix, it's a trivial change that improves the performance, especially with larger sample sizes (as measured with Apex performance test):
Size   Before  After
1kB   0.33mS  0.29mS
4kB  0.37mS   0.31mS
16kB 0.48mS  0.33mS
60kB 0.82mS  0.45mS
1MB  12mS    5.0mS
2MB  25mS    9.5mS