### PR TITLE
suppress invalid syntax warning for macro call

### DIFF
--- a/rmw_connext_cpp/src/rmw_client.cpp
+++ b/rmw_connext_cpp/src/rmw_client.cpp
@@ -179,6 +179,7 @@ rmw_create_client(
     goto fail;
   }
   // Use a placement new to construct the ConnextStaticClientInfo in the preallocated buffer.
+  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(client_info, buf, goto fail, ConnextStaticClientInfo, )
   buf = nullptr;  // Only free the client_info pointer; don't need the buf pointer anymore.
   client_info->requester_ = requester;

--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -179,6 +179,7 @@ rmw_create_publisher(
     goto fail;
   }
   // Use a placement new to construct the PublisherListener in the preallocated buffer.
+  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(publisher_listener, listener_buf, goto fail, ConnextPublisherListener, )
   listener_buf = nullptr;  // Only free the buffer pointer.
 

--- a/rmw_connext_cpp/src/rmw_service.cpp
+++ b/rmw_connext_cpp/src/rmw_service.cpp
@@ -180,6 +180,7 @@ rmw_create_service(
     goto fail;
   }
   // Use a placement new to construct the ConnextStaticServiceInfo in the preallocated buffer.
+  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(service_info, buf, goto fail, ConnextStaticServiceInfo, )
   buf = nullptr;  // Only free the service_info pointer; don't need the buf pointer anymore.
   service_info->replier_ = replier;

--- a/rmw_connext_cpp/src/rmw_subscription.cpp
+++ b/rmw_connext_cpp/src/rmw_subscription.cpp
@@ -174,6 +174,7 @@ rmw_create_subscription(
     goto fail;
   }
   // Use a placement new to construct the ConnextSubscriberListener in the preallocated buffer.
+  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(subscriber_listener, listener_buf, goto fail, ConnextSubscriberListener, )
   listener_buf = nullptr;  // Only free the buffer pointer.
 


### PR DESCRIPTION
use the inline suppressing function of cppcheck to disable the `syntaxError` warnings shown here:
https://ci.ros2.org/view/nightly/job/nightly_win_rel/1338/testReport/junit/(root)/projectroot/cppcheck_2/

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8347)](https://ci.ros2.org/job/ci_linux/8347/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6803)](http://ci.ros2.org/job/ci_osx/6803/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8249)](http://ci.ros2.org/job/ci_windows/8249/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>