### PR TITLE
assert that unmodified lines in the patch match the input

### DIFF
--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -54,6 +54,11 @@ def apply_patch(s, patch):
                 line = p[i]
                 i += 1
             if len(line) > 0:
+                if line[0] == ' ':
+                    # ensure that any unmodified line is the same
+                    # in the input file and in the patch file
+                    assert s[sl] == line[1:], \
+                        "s[%d] '%s' != line[1:] '%s'" % (sl, s[sl], line[1:])
                 if line[0] == sign or line[0] == ' ':
                     t += line[1:]
                 sl += (line[0] != sign)

--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.cxx.patch
@@ -10,7 +10,7 @@
 
  #ifndef osapi_type_h
 @@ -379,74 +379,81 @@ ConnextStaticSerializedDataPlugin_serialize(
-     RTIBool serialize_sample,
+     RTIBool serialize_sample, 
      void *endpoint_plugin_qos)
  {
 -    char * position = NULL;
@@ -150,9 +150,9 @@
 +  RTICdrStream_setBufferLength(stream, adjustedBufferLength);
  }
 
- RTIBool
+ RTIBool 
 @@ -458,114 +465,65 @@ ConnextStaticSerializedDataPlugin_deserialize_sample(
-     RTIBool deserialize_sample,
+     RTIBool deserialize_sample, 
      void *endpoint_plugin_qos)
  {
 +  char * position = NULL;
@@ -321,7 +321,7 @@
 
  RTIBool
 @@ -971,7 +929,9 @@ Key Management functions:
- PRESTypePluginKeyKind
+ PRESTypePluginKeyKind 
  ConnextStaticSerializedDataPlugin_get_key_kind(void)
  {
 -    return PRES_TYPEPLUGIN_USER_KEY;
@@ -330,20 +330,20 @@
 +    return PRES_TYPEPLUGIN_NO_KEY;
  }
 
- RTIBool
+ RTIBool 
 @@ -1408,6 +1368,11 @@ ConnextStaticSerializedDataPlugin_serialized_sample_to_keyhash(
  * ------------------------------------------------------------------------ */
- struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
- {
+ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void) 
+ { 
 +  return NULL;
 +}
 +
 +struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new_external(struct DDS_TypeCode * external_type_code)
 +{
      struct PRESTypePlugin *plugin = NULL;
-     const struct PRESTypePluginVersion PLUGIN_VERSION =
+     const struct PRESTypePluginVersion PLUGIN_VERSION = 
      PRES_TYPE_PLUGIN_VERSION_2_0;
-@@ -1503,7 +1468,7 @@ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
+@@ -1506,7 +1468,7 @@ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
      (PRESTypePluginKeyToInstanceFunction)
      ConnextStaticSerializedDataPlugin_key_to_instance;
      plugin->serializedKeyToKeyHashFnc = NULL; /* Not supported yet */


### PR DESCRIPTION
Otherwise an incorrectly applied patch file doesn't cause an error during patching (and we can only hope for a compiler error later).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8357)](http://ci.ros2.org/job/ci_linux/8357/) (assuming these test failures are unrelated)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6818)](http://ci.ros2.org/job/ci_osx/6818/) (failing on master with the same problems)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8267)](http://ci.ros2.org/job/ci_windows/8267/) (assuming these test failures are unrelated)