### PR TITLE
Support localhost only communication

### DIFF
--- a/rmw_connext_cpp/src/rmw_node.cpp
+++ b/rmw_connext_cpp/src/rmw_node.cpp
@@ -28,10 +28,12 @@ rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   return create_node(
-    rti_connext_identifier, context, name, namespace_, domain_id, security_options);
+    rti_connext_identifier, context, name, namespace_, domain_id, security_options,
+    localhost_only);
 }
 
 rmw_ret_t

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -298,10 +298,12 @@ rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   return create_node(
-    rti_connext_dynamic_identifier, context, name, namespace_, domain_id, security_options);
+    rti_connext_dynamic_identifier, context, name, namespace_, domain_id, security_options,
+    localhost_only);
 }
 
 rmw_ret_t

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/node.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/node.hpp
@@ -27,7 +27,8 @@ create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * options);
+  const rmw_node_security_options_t * options,
+  bool localhost_only);
 
 RMW_CONNEXT_SHARED_CPP_PUBLIC
 rmw_ret_t

--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -32,7 +32,8 @@ create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, NULL);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -57,6 +58,18 @@ create_node(
   if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default participant qos");
     return NULL;
+  }
+
+  if (localhost_only) {
+    status = DDS::PropertyQosPolicyHelper::add_property(
+    participant_qos.property,
+    "dds.transport.UDPv4.builtin.parent.allow_interfaces",
+    "127.0.0.1",
+    DDS::BOOLEAN_FALSE);
+    if (status != DDS::RETCODE_OK) {
+      RMW_SET_ERROR_MSG("failed to add qos property");
+      return NULL;
+    }
   }
   // This String_dup is not matched with a String_free because DDS appears to
   // free this automatically.

--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -62,12 +62,13 @@ create_node(
 
   if (localhost_only) {
     status = DDS::PropertyQosPolicyHelper::add_property(
-    participant_qos.property,
-    "dds.transport.UDPv4.builtin.parent.allow_interfaces",
-    "127.0.0.1",
-    DDS::BOOLEAN_FALSE);
+      participant_qos.property,
+      "dds.transport.UDPv4.builtin.parent.allow_interfaces",
+      "127.0.0.1",
+      DDS::BOOLEAN_FALSE);
     if (status != DDS::RETCODE_OK) {
-      RMW_SET_ERROR_MSG("failed to add qos property");
+      RMW_SET_ERROR_MSG(
+        "failed to add qos property to set localhost as the only network interface");
       return NULL;
     }
   }


### PR DESCRIPTION
Permit localhost communication only. Connected to this [issue](https://github.com/ros2/ros2/issues/798)

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8441)](https://ci.ros2.org/job/ci_linux/8441/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4343)](https://ci.ros2.org/job/ci_linux-aarch64/4343/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8352)](https://ci.ros2.org/job/ci_windows/8352/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6866)](https://ci.ros2.org/job/ci_osx/6866/)