### PR TITLE
update logic / patches to optionally support Connext 6

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -94,14 +94,33 @@ add_custom_command(
   VERBATIM
 )
 
+# determine major version of Connext
+find_file(connext_version_header "ndds_version.h"
+  PATHS ${Connext_INCLUDE_DIRS}
+  PATH_SUFFIXES "ndds"
+  NO_DEFAULT_PATH)
+if(NOT connext_version_header)
+  message(FATAL_ERROR "Failed to find 'ndds/ndds_version.h' in '${Connext_INCLUDE_DIRS}'")
+endif()
+file(STRINGS "${connext_version_header}" connext_define_major_version LIMIT_COUNT 1 REGEX "#define RTI_DDS_VERSION_MAJOR  [0-9]+")
+if("${connext_define_major_version}" STREQUAL "")
+  message(FATAL_ERROR "Failed to find '#define RTI_DDS_VERSION_MAJOR' in '${connext_version_header}'")
+endif()
+string(REGEX REPLACE ".* ([0-9]+)" "\\1" connext_major_version "${connext_define_major_version}")
+
 # patch the generate code for raw data
+if("${connext_major_version}" LESS 6)
+  set(patch_files_subdirectory "patch_files")
+else()
+  set(patch_files_subdirectory "patch_files_v6")
+endif()
 set(patch_files
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_data.cxx.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_data.h.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_dataPlugin.cxx.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_dataPlugin.h.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_dataSupport.cxx.patch
-  ${CMAKE_CURRENT_SOURCE_DIR}/resources/patch_files/connext_static_serialized_dataSupport.h.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_data.cxx.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_data.h.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_dataPlugin.cxx.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_dataPlugin.h.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_dataSupport.cxx.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${patch_files_subdirectory}/connext_static_serialized_dataSupport.h.patch
 )
 set(patched_directory "${CMAKE_CURRENT_BINARY_DIR}/resources/patched")
 file(MAKE_DIRECTORY ${patched_directory})

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.cxx.patch
@@ -1,0 +1,11 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_data.cxx
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_data.cxx
+@@ -11,7 +11,7 @@ or consult the RTI Connext manual.
+ 
+ #ifndef NDDS_STANDALONE_TYPE
+ #ifndef ndds_cpp_h
+-#include "ndds/ndds_cpp.h"
++#include "rmw_connext_shared_cpp/ndds_include.hpp"
+ #endif
+ #ifndef dds_c_log_impl_h              
+ #include "dds_c/dds_c_log_impl.h"                                

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.h.patch
@@ -1,0 +1,11 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_data.h
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_data.h
+@@ -14,7 +14,7 @@ or consult the RTI Connext manual.
+ 
+ #ifndef NDDS_STANDALONE_TYPE
+ #ifndef ndds_cpp_h
+-#include "ndds/ndds_cpp.h"
++#include "rmw_connext_shared_cpp/ndds_include.hpp"
+ #endif
+ #else
+ #include "ndds_standalone_type.h"

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_data.h.patch
@@ -7,5 +7,20 @@
 -#include "ndds/ndds_cpp.h"
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
+ #include "rti/xcdr/Interpreter.hpp"
  #else
- #include "ndds_standalone_type.h"
+@@ -63,7 +63,14 @@ or consult the RTI Connext manual.
+ NDDSUSERDllExport RTIXCdrSampleAccessInfo *ConnextStaticSerializedData_get_sample_seq_access_info(void);
+ #endif
+ 
++#ifndef _WIN32
++# pragma GCC diagnostic push
++# pragma GCC diagnostic ignored "-Wpedantic"
++#endif
+ DDS_SEQUENCE(ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
++#ifndef _WIN32
++# pragma GCC diagnostic pop
++#endif
+ 
+ NDDSUSERDllExport
+ RTIBool ConnextStaticSerializedData_initialize(

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.cxx.patch
@@ -1,0 +1,353 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.cxx
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.cxx
+@@ -11,7 +11,7 @@ or consult the RTI Connext manual.
+ #include <string.h>
+
+ #ifndef ndds_cpp_h
+-#include "ndds/ndds_cpp.h"
++#include "rmw_connext_shared_cpp/ndds_include.hpp"
+ #endif
+
+ #ifndef osapi_type_h
+@@ -379,74 +379,81 @@ ConnextStaticSerializedDataPlugin_serialize(
+     RTIBool serialize_sample, 
+     void *endpoint_plugin_qos)
+ {
+-    char * position = NULL;
+-    RTIBool retval = RTI_TRUE;
+-
+-    if (endpoint_data) {} /* To avoid warnings */
+-    if (endpoint_plugin_qos) {} /* To avoid warnings */
+-
+-    if(serialize_encapsulation) {
+-        if (!RTICdrStream_serializeAndSetCdrEncapsulation(stream , encapsulation_id)) {
+-            return RTI_FALSE;
+-        }
++  char * position = NULL;
++  RTIBool retval = RTI_TRUE;
++
++  if (endpoint_data) {}   /* To avoid warnings */
++  if (endpoint_plugin_qos) {}   /* To avoid warnings */
++
++  /* This plugin can only be used to publish the top-level DDS Topic-Type
++   * in which case serialize_encapsulation==TRUE. If that is not
++   * the case then it is an error.
++   */
++  if (!serialize_encapsulation) {
++    return RTI_FALSE;
++  }
++
++  position = RTICdrStream_resetAlignment(stream);
++
++  if (serialize_sample) {
++    /* The sample->serialized_data contains the serialized encapsulation followed by the serialized
++     * data, so we only need to copy that into
++     * the CDR stream. Not the key_hash, not the length of the data itself
++     * The SerializedType sample->serialized_data is always a contiguous buffer
++     */
++    DDS_Octet * buffer = DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data);
++    if (buffer == NULL) {
++      return RTI_FALSE;
++    }
+
+-        position = RTICdrStream_resetAlignment(stream);
++    /* The encapsulation_id appears in the sample->serialized_data as octet[2] using big-endian
++     * byte order
++     */
++    if (encapsulation_id != (buffer[0] * 256 + buffer[1]) ) {
++      return RTI_FALSE;
+     }
+
+-    if(serialize_sample) {
++    /* Use RTICdrStream_serializePrimitiveArray so that there is no additional length prepended */
++    if (!RTICdrStream_serializePrimitiveArray(
++        stream, (void *)buffer,
++        DDS_OctetSeq_get_length(&sample->serialized_data),
++        RTI_CDR_OCTET_TYPE))
++    {
++      return RTI_FALSE;
++    }
++  }
+
+-        if (!RTICdrStream_serializePrimitiveArray(
+-            stream, (void*) sample->key_hash, ((KEY_HASH_LENGTH_16)), RTI_CDR_OCTET_TYPE)) {
+-            return RTI_FALSE;
+-        }
++  RTICdrStream_restoreAlignment(stream, position);
+
+-        if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key) != NULL) {
+-            if (!RTICdrStream_serializePrimitiveSequence(
+-                stream,
+-                DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key),
+-                DDS_OctetSeq_get_length(&sample->serialized_key),
+-                (RTI_INT32_MAX-1),
+-                RTI_CDR_OCTET_TYPE)) {
+-                return RTI_FALSE;
+-            }
+-        } else {
+-            if (!RTICdrStream_serializePrimitivePointerSequence(
+-                stream,
+-                (const void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_key),
+-                DDS_OctetSeq_get_length(&sample->serialized_key),
+-                (RTI_INT32_MAX-1),
+-                RTI_CDR_OCTET_TYPE)) {
+-                return RTI_FALSE;
+-            }
+-        }
+-
+-        if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data) != NULL) {
+-            if (!RTICdrStream_serializePrimitiveSequence(
+-                stream,
+-                DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data),
+-                DDS_OctetSeq_get_length(&sample->serialized_data),
+-                (RTI_INT32_MAX-1),
+-                RTI_CDR_OCTET_TYPE)) {
+-                return RTI_FALSE;
+-            }
+-        } else {
+-            if (!RTICdrStream_serializePrimitivePointerSequence(
+-                stream,
+-                (const void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_data),
+-                DDS_OctetSeq_get_length(&sample->serialized_data),
+-                (RTI_INT32_MAX-1),
+-                RTI_CDR_OCTET_TYPE)) {
+-                return RTI_FALSE;
+-            }
+-        }
++  return retval;
++}
+
+-    }
++/**
++    TODO. The code-block below does not belong here.
++    It should be pushed to the CDR module, perhaps inside
++    RTICdrStream_deserializeAndSetCdrEncapsulation so that the
++    stream size is already correct when SerializedTypePlugin_deserialize_sample
++    is called.
+
+-    if(serialize_encapsulation) {
+-        RTICdrStream_restoreAlignment(stream,position);
+-    }
++    Adjust the size of the CDR stream to not include the alignment
++    padding. See http://issues.omg.org/browse/DDSXTY12-10
+
+-    return retval;
++    @precondition The RTICdrStream *stream has already processed
++                  the encapsulation header and therefore has set the
++                  encapsulation options returned by
++                  RTICdrStream_getEncapsulationOptions()
++*/
++void
++ConnextStaticSerializedDataPlugin_remove_padding_from_stream(struct RTICdrStream * stream)
++{
++  /* See http://issues.omg.org/browse/DDSXTY12-10 */
++  DDS_UnsignedShort padding_size_mask = 0x0003;
++  DDS_UnsignedShort padding_size;
++  int adjustedBufferLength;
++
++  padding_size = RTICdrStream_getEncapsulationOptions(stream) & padding_size_mask;
++  adjustedBufferLength = RTICdrStream_getBufferLength(stream) - padding_size;
++  RTICdrStream_setBufferLength(stream, adjustedBufferLength);
+ }
+
+ RTIBool 
+@@ -458,114 +465,65 @@ ConnextStaticSerializedDataPlugin_deserialize_sample(
+     RTIBool deserialize_sample, 
+     void *endpoint_plugin_qos)
+ {
++  char * position = NULL;
++  RTIBool done = RTI_FALSE;
++
++  if (endpoint_data) {}   /* To avoid warnings */
++  if (endpoint_plugin_qos) {}   /* To avoid warnings */
++
++  /* This plugin can only be used to publish the top-level DDS Topic-Type
++   * in which case deserialize_encapsulation==TRUE. If that is not
++   * the case then it is an error.
++   */
++  if (!deserialize_encapsulation) {
++    return RTI_FALSE;
++  }
++
++  position = RTICdrStream_resetAlignment(stream);
++
++  /* TODO. The call does not belong here. It should be pushed
++   * inside RTICdrStream_deserializeAndSetCdrEncapsulation
++   */
++  ConnextStaticSerializedDataPlugin_remove_padding_from_stream(stream);
++
++  if (deserialize_sample) {
++    /* Note that sample->key_hash was already set by SerializedTypePlugin_deserialize()
++       it is done there because SerializedTypePlugin_deserialize_sample does not
++       have access to the SampleInfo where that information is
++    */
++
++    /* We do not set the serialized_key on deserialization */
++    DDS_OctetSeq_set_length(&sample->serialized_key, 0);
++
++    /* We copy everything that remains in the CDR stream */
++    int bytesLeftInStream = RTICdrStream_getRemainder(stream);
++    DDS_Octet * cdrBufferPtr = (DDS_Octet *) RTICdrStream_getCurrentPosition(stream);
++    if (cdrBufferPtr == NULL) {
++      goto fin;
++    }
+
+-    char * position = NULL;
+-
+-    RTIBool done = RTI_FALSE;
+-
+-    try {
+-
+-        if (endpoint_data) {} /* To avoid warnings */
+-        if (endpoint_plugin_qos) {} /* To avoid warnings */
+-        if(deserialize_encapsulation) {
+-
+-            if (!RTICdrStream_deserializeAndSetCdrEncapsulation(stream)) {
+-                return RTI_FALSE;
+-            }
+-
+-            position = RTICdrStream_resetAlignment(stream);
+-        }
+-        if(deserialize_sample) {
+-
+-            ConnextStaticSerializedData_initialize_ex(sample, RTI_FALSE, RTI_FALSE);
+-
+-            if (!RTICdrStream_deserializePrimitiveArray(
+-                stream, (void*) sample->key_hash, ((KEY_HASH_LENGTH_16)), RTI_CDR_OCTET_TYPE)) {
+-                goto fin;
+-            }
+-
+-            {
+-                RTICdrUnsignedLong sequence_length;
+-                if (!RTICdrStream_lookUnsignedLong(stream,&sequence_length)) {
+-                    goto fin;
+-                }
+-                if (!DDS_OctetSeq_set_maximum(&sample->serialized_key,sequence_length)) {
+-                    return RTI_FALSE;
+-                }
+-                if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key) != NULL) {
+-                    if (!RTICdrStream_deserializePrimitiveSequence(
+-                        stream,
+-                        DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key),
+-                        &sequence_length,
+-                        DDS_OctetSeq_get_maximum(&sample->serialized_key),
+-                        RTI_CDR_OCTET_TYPE)){
+-                        goto fin;
+-                    }
+-                } else {
+-                    if (!RTICdrStream_deserializePrimitivePointerSequence(
+-                        stream,
+-                        (void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_key),
+-                        &sequence_length,
+-                        DDS_OctetSeq_get_maximum(&sample->serialized_key),
+-                        RTI_CDR_OCTET_TYPE)){
+-                        goto fin;
+-                    }
+-                }
+-                if (!DDS_OctetSeq_set_length(&sample->serialized_key, sequence_length)) {
+-                    return RTI_FALSE;
+-                }
+-
+-            }
+-            {
+-                RTICdrUnsignedLong sequence_length;
+-                if (!RTICdrStream_lookUnsignedLong(stream,&sequence_length)) {
+-                    goto fin;
+-                }
+-                if (!DDS_OctetSeq_set_maximum(&sample->serialized_data,sequence_length)) {
+-                    return RTI_FALSE;
+-                }
+-                if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data) != NULL) {
+-                    if (!RTICdrStream_deserializePrimitiveSequence(
+-                        stream,
+-                        DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data),
+-                        &sequence_length,
+-                        DDS_OctetSeq_get_maximum(&sample->serialized_data),
+-                        RTI_CDR_OCTET_TYPE)){
+-                        goto fin;
+-                    }
+-                } else {
+-                    if (!RTICdrStream_deserializePrimitivePointerSequence(
+-                        stream,
+-                        (void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_data),
+-                        &sequence_length,
+-                        DDS_OctetSeq_get_maximum(&sample->serialized_data),
+-                        RTI_CDR_OCTET_TYPE)){
+-                        goto fin;
+-                    }
+-                }
+-                if (!DDS_OctetSeq_set_length(&sample->serialized_data, sequence_length)) {
+-                    return RTI_FALSE;
+-                }
++    /* Do not call SerializedType_initialize_ex initialize here
++       because it would override the key_hash field
++       SerializedType_initialize_ex(sample, RTI_FALSE, RTI_FALSE);
++     */
++    if (!DDS_OctetSeq_from_array(&sample->serialized_data, cdrBufferPtr, bytesLeftInStream) ) {
++      goto fin;
++    }
++    RTICdrStream_incrementCurrentPosition(stream, bytesLeftInStream);
++  }
+
+-            }
+-        }
++  done = RTI_TRUE;
+
+-        done = RTI_TRUE;
+-      fin:
+-        if (done != RTI_TRUE &&
+-        RTICdrStream_getRemainder(stream) >=
+-        RTI_CDR_PARAMETER_HEADER_ALIGNMENT) {
+-            return RTI_FALSE;
+-        }
+-        if(deserialize_encapsulation) {
+-            RTICdrStream_restoreAlignment(stream,position);
+-        }
++fin:
++  if ( (done != RTI_TRUE) &&
++    (RTICdrStream_getRemainder(stream) >= RTI_CDR_PARAMETER_HEADER_ALIGNMENT) )
++  {
++    return RTI_FALSE;
++  }
+
+-        return RTI_TRUE;
++  RTICdrStream_restoreAlignment(stream, position);
+
+-    } catch (std::bad_alloc&) {
+-        return RTI_FALSE;
+-    }
++  return RTI_TRUE;
+ }
+
+ RTIBool
+@@ -971,7 +929,9 @@ Key Management functions:
+ PRESTypePluginKeyKind 
+ ConnextStaticSerializedDataPlugin_get_key_kind(void)
+ {
+-    return PRES_TYPEPLUGIN_USER_KEY;
++    // TODO(karsten1987): Whenever we introduce keys for our data types
++    // this might have to change.
++    return PRES_TYPEPLUGIN_NO_KEY;
+ }
+
+ RTIBool 
+@@ -1408,6 +1368,11 @@ ConnextStaticSerializedDataPlugin_serialized_sample_to_keyhash(
+ * ------------------------------------------------------------------------ */
+ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void) 
+ { 
++  return NULL;
++}
++
++struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new_external(struct DDS_TypeCode * external_type_code)
++{
+     struct PRESTypePlugin *plugin = NULL;
+     const struct PRESTypePluginVersion PLUGIN_VERSION = 
+     PRES_TYPE_PLUGIN_VERSION_2_0;
+@@ -1506,7 +1468,7 @@ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
+     (PRESTypePluginKeyToInstanceFunction)
+     ConnextStaticSerializedDataPlugin_key_to_instance;
+     plugin->serializedKeyToKeyHashFnc = NULL; /* Not supported yet */
+-    plugin->typeCode =  (struct RTICdrTypeCode *)ConnextStaticSerializedData_get_typecode();
++    plugin->typeCode =  (struct RTICdrTypeCode *)external_type_code;
+
+     plugin->languageKind = PRES_TYPEPLUGIN_CPP_LANG;

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.cxx.patch
@@ -2,325 +2,14 @@
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.cxx
 @@ -11,7 +11,7 @@ or consult the RTI Connext manual.
  #include <string.h>
-
+ 
  #ifndef ndds_cpp_h
 -#include "ndds/ndds_cpp.h"
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
-
+ 
  #ifndef osapi_type_h
-@@ -379,74 +379,81 @@ ConnextStaticSerializedDataPlugin_serialize(
-     RTIBool serialize_sample, 
-     void *endpoint_plugin_qos)
- {
--    char * position = NULL;
--    RTIBool retval = RTI_TRUE;
--
--    if (endpoint_data) {} /* To avoid warnings */
--    if (endpoint_plugin_qos) {} /* To avoid warnings */
--
--    if(serialize_encapsulation) {
--        if (!RTICdrStream_serializeAndSetCdrEncapsulation(stream , encapsulation_id)) {
--            return RTI_FALSE;
--        }
-+  char * position = NULL;
-+  RTIBool retval = RTI_TRUE;
-+
-+  if (endpoint_data) {}   /* To avoid warnings */
-+  if (endpoint_plugin_qos) {}   /* To avoid warnings */
-+
-+  /* This plugin can only be used to publish the top-level DDS Topic-Type
-+   * in which case serialize_encapsulation==TRUE. If that is not
-+   * the case then it is an error.
-+   */
-+  if (!serialize_encapsulation) {
-+    return RTI_FALSE;
-+  }
-+
-+  position = RTICdrStream_resetAlignment(stream);
-+
-+  if (serialize_sample) {
-+    /* The sample->serialized_data contains the serialized encapsulation followed by the serialized
-+     * data, so we only need to copy that into
-+     * the CDR stream. Not the key_hash, not the length of the data itself
-+     * The SerializedType sample->serialized_data is always a contiguous buffer
-+     */
-+    DDS_Octet * buffer = DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data);
-+    if (buffer == NULL) {
-+      return RTI_FALSE;
-+    }
-
--        position = RTICdrStream_resetAlignment(stream);
-+    /* The encapsulation_id appears in the sample->serialized_data as octet[2] using big-endian
-+     * byte order
-+     */
-+    if (encapsulation_id != (buffer[0] * 256 + buffer[1]) ) {
-+      return RTI_FALSE;
-     }
-
--    if(serialize_sample) {
-+    /* Use RTICdrStream_serializePrimitiveArray so that there is no additional length prepended */
-+    if (!RTICdrStream_serializePrimitiveArray(
-+        stream, (void *)buffer,
-+        DDS_OctetSeq_get_length(&sample->serialized_data),
-+        RTI_CDR_OCTET_TYPE))
-+    {
-+      return RTI_FALSE;
-+    }
-+  }
-
--        if (!RTICdrStream_serializePrimitiveArray(
--            stream, (void*) sample->key_hash, ((KEY_HASH_LENGTH_16)), RTI_CDR_OCTET_TYPE)) {
--            return RTI_FALSE;
--        }
-+  RTICdrStream_restoreAlignment(stream, position);
-
--        if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key) != NULL) {
--            if (!RTICdrStream_serializePrimitiveSequence(
--                stream,
--                DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key),
--                DDS_OctetSeq_get_length(&sample->serialized_key),
--                (RTI_INT32_MAX-1),
--                RTI_CDR_OCTET_TYPE)) {
--                return RTI_FALSE;
--            }
--        } else {
--            if (!RTICdrStream_serializePrimitivePointerSequence(
--                stream,
--                (const void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_key),
--                DDS_OctetSeq_get_length(&sample->serialized_key),
--                (RTI_INT32_MAX-1),
--                RTI_CDR_OCTET_TYPE)) {
--                return RTI_FALSE;
--            }
--        }
--
--        if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data) != NULL) {
--            if (!RTICdrStream_serializePrimitiveSequence(
--                stream,
--                DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data),
--                DDS_OctetSeq_get_length(&sample->serialized_data),
--                (RTI_INT32_MAX-1),
--                RTI_CDR_OCTET_TYPE)) {
--                return RTI_FALSE;
--            }
--        } else {
--            if (!RTICdrStream_serializePrimitivePointerSequence(
--                stream,
--                (const void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_data),
--                DDS_OctetSeq_get_length(&sample->serialized_data),
--                (RTI_INT32_MAX-1),
--                RTI_CDR_OCTET_TYPE)) {
--                return RTI_FALSE;
--            }
--        }
-+  return retval;
-+}
-
--    }
-+/**
-+    TODO. The code-block below does not belong here.
-+    It should be pushed to the CDR module, perhaps inside
-+    RTICdrStream_deserializeAndSetCdrEncapsulation so that the
-+    stream size is already correct when SerializedTypePlugin_deserialize_sample
-+    is called.
-
--    if(serialize_encapsulation) {
--        RTICdrStream_restoreAlignment(stream,position);
--    }
-+    Adjust the size of the CDR stream to not include the alignment
-+    padding. See http://issues.omg.org/browse/DDSXTY12-10
-
--    return retval;
-+    @precondition The RTICdrStream *stream has already processed
-+                  the encapsulation header and therefore has set the
-+                  encapsulation options returned by
-+                  RTICdrStream_getEncapsulationOptions()
-+*/
-+void
-+ConnextStaticSerializedDataPlugin_remove_padding_from_stream(struct RTICdrStream * stream)
-+{
-+  /* See http://issues.omg.org/browse/DDSXTY12-10 */
-+  DDS_UnsignedShort padding_size_mask = 0x0003;
-+  DDS_UnsignedShort padding_size;
-+  int adjustedBufferLength;
-+
-+  padding_size = RTICdrStream_getEncapsulationOptions(stream) & padding_size_mask;
-+  adjustedBufferLength = RTICdrStream_getBufferLength(stream) - padding_size;
-+  RTICdrStream_setBufferLength(stream, adjustedBufferLength);
- }
-
- RTIBool 
-@@ -458,114 +465,65 @@ ConnextStaticSerializedDataPlugin_deserialize_sample(
-     RTIBool deserialize_sample, 
-     void *endpoint_plugin_qos)
- {
-+  char * position = NULL;
-+  RTIBool done = RTI_FALSE;
-+
-+  if (endpoint_data) {}   /* To avoid warnings */
-+  if (endpoint_plugin_qos) {}   /* To avoid warnings */
-+
-+  /* This plugin can only be used to publish the top-level DDS Topic-Type
-+   * in which case deserialize_encapsulation==TRUE. If that is not
-+   * the case then it is an error.
-+   */
-+  if (!deserialize_encapsulation) {
-+    return RTI_FALSE;
-+  }
-+
-+  position = RTICdrStream_resetAlignment(stream);
-+
-+  /* TODO. The call does not belong here. It should be pushed
-+   * inside RTICdrStream_deserializeAndSetCdrEncapsulation
-+   */
-+  ConnextStaticSerializedDataPlugin_remove_padding_from_stream(stream);
-+
-+  if (deserialize_sample) {
-+    /* Note that sample->key_hash was already set by SerializedTypePlugin_deserialize()
-+       it is done there because SerializedTypePlugin_deserialize_sample does not
-+       have access to the SampleInfo where that information is
-+    */
-+
-+    /* We do not set the serialized_key on deserialization */
-+    DDS_OctetSeq_set_length(&sample->serialized_key, 0);
-+
-+    /* We copy everything that remains in the CDR stream */
-+    int bytesLeftInStream = RTICdrStream_getRemainder(stream);
-+    DDS_Octet * cdrBufferPtr = (DDS_Octet *) RTICdrStream_getCurrentPosition(stream);
-+    if (cdrBufferPtr == NULL) {
-+      goto fin;
-+    }
-
--    char * position = NULL;
--
--    RTIBool done = RTI_FALSE;
--
--    try {
--
--        if (endpoint_data) {} /* To avoid warnings */
--        if (endpoint_plugin_qos) {} /* To avoid warnings */
--        if(deserialize_encapsulation) {
--
--            if (!RTICdrStream_deserializeAndSetCdrEncapsulation(stream)) {
--                return RTI_FALSE;
--            }
--
--            position = RTICdrStream_resetAlignment(stream);
--        }
--        if(deserialize_sample) {
--
--            ConnextStaticSerializedData_initialize_ex(sample, RTI_FALSE, RTI_FALSE);
--
--            if (!RTICdrStream_deserializePrimitiveArray(
--                stream, (void*) sample->key_hash, ((KEY_HASH_LENGTH_16)), RTI_CDR_OCTET_TYPE)) {
--                goto fin;
--            }
--
--            {
--                RTICdrUnsignedLong sequence_length;
--                if (!RTICdrStream_lookUnsignedLong(stream,&sequence_length)) {
--                    goto fin;
--                }
--                if (!DDS_OctetSeq_set_maximum(&sample->serialized_key,sequence_length)) {
--                    return RTI_FALSE;
--                }
--                if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key) != NULL) {
--                    if (!RTICdrStream_deserializePrimitiveSequence(
--                        stream,
--                        DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_key),
--                        &sequence_length,
--                        DDS_OctetSeq_get_maximum(&sample->serialized_key),
--                        RTI_CDR_OCTET_TYPE)){
--                        goto fin;
--                    }
--                } else {
--                    if (!RTICdrStream_deserializePrimitivePointerSequence(
--                        stream,
--                        (void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_key),
--                        &sequence_length,
--                        DDS_OctetSeq_get_maximum(&sample->serialized_key),
--                        RTI_CDR_OCTET_TYPE)){
--                        goto fin;
--                    }
--                }
--                if (!DDS_OctetSeq_set_length(&sample->serialized_key, sequence_length)) {
--                    return RTI_FALSE;
--                }
--
--            }
--            {
--                RTICdrUnsignedLong sequence_length;
--                if (!RTICdrStream_lookUnsignedLong(stream,&sequence_length)) {
--                    goto fin;
--                }
--                if (!DDS_OctetSeq_set_maximum(&sample->serialized_data,sequence_length)) {
--                    return RTI_FALSE;
--                }
--                if (DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data) != NULL) {
--                    if (!RTICdrStream_deserializePrimitiveSequence(
--                        stream,
--                        DDS_OctetSeq_get_contiguous_bufferI(&sample->serialized_data),
--                        &sequence_length,
--                        DDS_OctetSeq_get_maximum(&sample->serialized_data),
--                        RTI_CDR_OCTET_TYPE)){
--                        goto fin;
--                    }
--                } else {
--                    if (!RTICdrStream_deserializePrimitivePointerSequence(
--                        stream,
--                        (void **) DDS_OctetSeq_get_discontiguous_bufferI(&sample->serialized_data),
--                        &sequence_length,
--                        DDS_OctetSeq_get_maximum(&sample->serialized_data),
--                        RTI_CDR_OCTET_TYPE)){
--                        goto fin;
--                    }
--                }
--                if (!DDS_OctetSeq_set_length(&sample->serialized_data, sequence_length)) {
--                    return RTI_FALSE;
--                }
-+    /* Do not call SerializedType_initialize_ex initialize here
-+       because it would override the key_hash field
-+       SerializedType_initialize_ex(sample, RTI_FALSE, RTI_FALSE);
-+     */
-+    if (!DDS_OctetSeq_from_array(&sample->serialized_data, cdrBufferPtr, bytesLeftInStream) ) {
-+      goto fin;
-+    }
-+    RTICdrStream_incrementCurrentPosition(stream, bytesLeftInStream);
-+  }
-
--            }
--        }
-+  done = RTI_TRUE;
-
--        done = RTI_TRUE;
--      fin:
--        if (done != RTI_TRUE &&
--        RTICdrStream_getRemainder(stream) >=
--        RTI_CDR_PARAMETER_HEADER_ALIGNMENT) {
--            return RTI_FALSE;
--        }
--        if(deserialize_encapsulation) {
--            RTICdrStream_restoreAlignment(stream,position);
--        }
-+fin:
-+  if ( (done != RTI_TRUE) &&
-+    (RTICdrStream_getRemainder(stream) >= RTI_CDR_PARAMETER_HEADER_ALIGNMENT) )
-+  {
-+    return RTI_FALSE;
-+  }
-
--        return RTI_TRUE;
-+  RTICdrStream_restoreAlignment(stream, position);
-
--    } catch (std::bad_alloc&) {
--        return RTI_FALSE;
--    }
-+  return RTI_TRUE;
- }
-
- RTIBool
-@@ -971,7 +929,9 @@ Key Management functions:
+@@ -655,7 +929,9 @@ Key Management functions:
  PRESTypePluginKeyKind 
  ConnextStaticSerializedDataPlugin_get_key_kind(void)
  {
@@ -329,9 +18,9 @@
 +    // this might have to change.
 +    return PRES_TYPEPLUGIN_NO_KEY;
  }
-
- RTIBool 
-@@ -1408,6 +1368,11 @@ ConnextStaticSerializedDataPlugin_serialized_sample_to_keyhash(
+ 
+ RTIBool ConnextStaticSerializedDataPlugin_deserialize_key(
+@@ -895,6 +1368,11 @@ ConnextStaticSerializedDataPlugin_serialized_sample_to_keyhash(
  * ------------------------------------------------------------------------ */
  struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void) 
  { 
@@ -343,11 +32,14 @@
      struct PRESTypePlugin *plugin = NULL;
      const struct PRESTypePluginVersion PLUGIN_VERSION = 
      PRES_TYPE_PLUGIN_VERSION_2_0;
-@@ -1506,7 +1468,7 @@ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
+@@ -990,9 +1468,7 @@ struct PRESTypePlugin *ConnextStaticSerializedDataPlugin_new(void)
      (PRESTypePluginKeyToInstanceFunction)
      ConnextStaticSerializedDataPlugin_key_to_instance;
      plugin->serializedKeyToKeyHashFnc = NULL; /* Not supported yet */
+-    #ifdef NDDS_STANDALONE_TYPE
+-    plugin->typeCode = NULL; 
+-    #else
 -    plugin->typeCode =  (struct RTICdrTypeCode *)ConnextStaticSerializedData_get_typecode();
+-    #endif
 +    plugin->typeCode =  (struct RTICdrTypeCode *)external_type_code;
-
      plugin->languageKind = PRES_TYPEPLUGIN_CPP_LANG;

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.h.patch
@@ -1,0 +1,11 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
+@@ -324,6 +324,9 @@ extern "C" {
+     NDDSUSERDllExport extern struct PRESTypePlugin*
+     ConnextStaticSerializedDataPlugin_new(void);
+ 
++    NDDSUSERDllExport extern struct PRESTypePlugin*
++    ConnextStaticSerializedDataPlugin_new_external(struct DDS_TypeCode * external_type_code);
++
+     NDDSUSERDllExport extern void
+     ConnextStaticSerializedDataPlugin_delete(struct PRESTypePlugin *);

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataPlugin.h.patch
@@ -1,6 +1,6 @@
 --- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
-@@ -324,6 +324,9 @@ extern "C" {
+@@ -258,6 +258,9 @@ extern "C" {
      NDDSUSERDllExport extern struct PRESTypePlugin*
      ConnextStaticSerializedDataPlugin_new(void);
  

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.cxx.patch
@@ -1,0 +1,66 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
+@@ -115,3 +115,62 @@ Defines:   TTypeSupport, TData, TDataReader, TDataWriter
+ #undef TPlugin_new
+ #undef TPlugin_delete
+
++DDS_ReturnCode_t
++ConnextStaticSerializedDataSupport_register_external_type(
++  DDSDomainParticipant * participant,
++  const char * type_name,
++  struct DDS_TypeCode * type_code)
++{
++  DDSTypeSupport * dds_data_type = NULL;
++  struct PRESTypePlugin * presTypePlugin = NULL;
++  DDS_ReturnCode_t retcode = DDS_RETCODE_ERROR;
++  DDS_Boolean delete_data_type = DDS_BOOLEAN_FALSE;
++  RTIBool already_registered = RTI_FALSE;
++
++  if (type_code == NULL) {
++    goto finError;
++  }
++
++  if (participant == NULL) {
++    goto finError;
++  }
++
++  /* TODO pass the type_code */
++  presTypePlugin = ConnextStaticSerializedDataPlugin_new_external(type_code);
++  if (presTypePlugin == NULL) {
++    goto finError;
++  }
++
++  dds_data_type = new ConnextStaticSerializedDataTypeSupport(true);
++  if (dds_data_type == NULL) {
++    fprintf(stderr, "Error while registering external type\n");
++    goto finError;
++  }
++  delete_data_type = RTI_TRUE;
++
++  presTypePlugin->_userBuffer = (PRESWord *)dds_data_type;
++  already_registered = participant->is_type_registered(type_name);
++
++  retcode = participant->register_type(type_name, presTypePlugin, NULL, !already_registered);
++  if (retcode != DDS_RETCODE_OK) {
++    fprintf(stderr, "error while registering external type\n");
++    goto finError;
++  }
++
++  if (!already_registered) {
++    delete_data_type = DDS_BOOLEAN_FALSE;
++  }
++
++  retcode = DDS_RETCODE_OK;
++
++finError:
++  if (presTypePlugin != NULL) {
++    ConnextStaticSerializedDataPlugin_delete(presTypePlugin);
++  }
++  if (delete_data_type) {
++    delete (ConnextStaticSerializedDataTypeSupport *)dds_data_type;
++    dds_data_type = NULL;
++  }
++
++  return retcode;
++}
+

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.cxx.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.cxx.patch
@@ -1,6 +1,6 @@
 --- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.cxx
-@@ -115,3 +115,62 @@ Defines:   TTypeSupport, TData, TDataReader, TDataWriter
+@@ -123,3 +123,62 @@ Defines:   TTypeSupport, TData, TDataReader, TDataWriter
  #undef TPlugin_new
  #undef TPlugin_delete
 

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.h.patch
@@ -1,0 +1,121 @@
+--- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.h
++++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataSupport.h
+@@ -15,7 +15,7 @@ or consult the RTI Connext manual.
+ #include "connext_static_serialized_data.h"
+ 
+ #ifndef ndds_cpp_h
+-#include "ndds/ndds_cpp.h"
++#include "rmw_connext_shared_cpp/ndds_include.hpp"
+ #endif
+ 
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+@@ -44,13 +44,106 @@ implementing generics in C and C++.
+ 
+ #endif
+ 
+-DDS_TYPESUPPORT_CPP(
+-    ConnextStaticSerializedDataTypeSupport, 
+-    ConnextStaticSerializedData);
++class NDDSUSERDllExport DDSCPPDllExport ConnextStaticSerializedDataTypeSupport : public ::DDSTypeSupport
++{
++public:
++  ConnextStaticSerializedDataTypeSupport(bool osrf)
++  {
++    (void) osrf;
++  }
++
++  ~ConnextStaticSerializedDataTypeSupport();
++
++  static DDS_ReturnCode_t register_type(
++    DDSDomainParticipant * participant,
++    const char * type_name = "ConnextStaticSerializedData");
++
++  static DDS_ReturnCode_t unregister_type(
++    DDSDomainParticipant * participant,
++    const char * type_name = "ConnextStaticSerializedData");
++
++  static const char * get_type_name();
++
++  static ConnextStaticSerializedData * create_data_ex(DDS_Boolean allocatePointers);
++
++  static ConnextStaticSerializedData * create_data(
++    const DDS_TypeAllocationParams_t & alloc_params =
++    DDS_TYPE_ALLOCATION_PARAMS_DEFAULT);
++
++  static DDS_ReturnCode_t delete_data_ex(
++    ConnextStaticSerializedData * a_data,
++    DDS_Boolean deletePointers);
++
++  static DDS_ReturnCode_t delete_data(
++    ConnextStaticSerializedData * a_data,
++    const DDS_TypeDeallocationParams_t & dealloc_params =
++    DDS_TYPE_DEALLOCATION_PARAMS_DEFAULT);
++
++  static void print_data(const ConnextStaticSerializedData * a_data);
++
++  static DDS_ReturnCode_t copy_data(
++    ConnextStaticSerializedData * dst_data, const ConnextStaticSerializedData * src_data);
++
++  static DDS_ReturnCode_t initialize_data_ex(
++    ConnextStaticSerializedData * a_data,
++    DDS_Boolean allocatePointers);
++
++  static DDS_ReturnCode_t initialize_data(
++    ConnextStaticSerializedData * a_data,
++    const DDS_TypeAllocationParams_t & alloc_params =
++    DDS_TYPE_ALLOCATION_PARAMS_DEFAULT);
++
++  static DDS_ReturnCode_t finalize_data_ex(
++    ConnextStaticSerializedData * a_data,
++    DDS_Boolean deletePointers);
++
++  static DDS_ReturnCode_t finalize_data(
++    ConnextStaticSerializedData * a_data,
++    const DDS_TypeDeallocationParams_t & dealloc_params =
++    DDS_TYPE_DEALLOCATION_PARAMS_DEFAULT);
++
++  DDSDataReader * create_datareaderI(DDSDataReader * dataReader);
++
++  DDS_ReturnCode_t destroy_datareaderI(DDSDataReader * dataReader);
++
++  DDSDataWriter * create_datawriterI(DDSDataWriter * dataWriter);
++
++  DDS_ReturnCode_t destroy_datawriterI(DDSDataWriter * dataWriter);
++
++  static DDS_TypeCode * get_typecode();
++
++  static DDS_ReturnCode_t serialize_data_to_cdr_buffer(
++    char * buffer,
++    unsigned int & length,
++    const ConnextStaticSerializedData * a_data);
++
++  static DDS_ReturnCode_t deserialize_data_from_cdr_buffer(
++    ConnextStaticSerializedData * a_data,
++    const char * buffer,
++    unsigned int length);
++
++  static DDS_ReturnCode_t data_to_string(
++    ConnextStaticSerializedData * sample,
++    char * str,
++    DDS_UnsignedLong & str_size,
++    const DDS_PrintFormatProperty & property);
++
++  static void finalize();
++
++private:
++  ConnextStaticSerializedDataTypeSupport();
++};
+ 
+ DDS_DATAWRITER_CPP(ConnextStaticSerializedDataDataWriter, ConnextStaticSerializedData);
+ DDS_DATAREADER_CPP(ConnextStaticSerializedDataDataReader, ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
+ 
++NDDSUSERDllExport
++DDS_ReturnCode_t
++ConnextStaticSerializedDataSupport_register_external_type(
++  DDSDomainParticipant * participant,
++  const char * type_name,
++  struct DDS_TypeCode * type_code);
++
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+ /* If the code is building on Windows, stop exporting symbols.
+ */

--- a/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.h.patch
+++ b/rmw_connext_cpp/resources/patch_files_v6/connext_static_serialized_dataSupport.h.patch
@@ -8,7 +8,7 @@
 +#include "rmw_connext_shared_cpp/ndds_include.hpp"
  #endif
  
- #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE) || defined(RTI_INTIME)) && defined(NDDS_USER_DLL_EXPORT)
 @@ -44,13 +44,106 @@ implementing generics in C and C++.
  
  #endif
@@ -89,6 +89,12 @@
 +    unsigned int & length,
 +    const ConnextStaticSerializedData * a_data);
 +
++  static DDS_ReturnCode_t serialize_data_to_cdr_buffer_ex(
++    char * buffer,
++    unsigned int & length,
++    const ConnextStaticSerializedData * a_data,
++    DDS_DataRepresentationId_t representation);
++
 +  static DDS_ReturnCode_t deserialize_data_from_cdr_buffer(
 +    ConnextStaticSerializedData * a_data,
 +    const char * buffer,
@@ -106,8 +112,12 @@
 +  ConnextStaticSerializedDataTypeSupport();
 +};
  
- DDS_DATAWRITER_CPP(ConnextStaticSerializedDataDataWriter, ConnextStaticSerializedData);
- DDS_DATAREADER_CPP(ConnextStaticSerializedDataDataReader, ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
+ #define ENABLE_TDATAWRITER_DATA_CONSTRUCTOR_METHODS
+ DDS_DATAWRITER_WITH_DATA_CONSTRUCTOR_METHODS_CPP(ConnextStaticSerializedDataDataWriter, ConnextStaticSerializedData);
+ #undef ENABLE_TDATAWRITER_DATA_CONSTRUCTOR_METHODS
+ #define ENABLE_TDATAREADER_DATA_CONSISTENCY_CHECK_METHOD
+ DDS_DATAREADER_W_DATA_CONSISTENCY_CHECK(ConnextStaticSerializedDataDataReader, ConnextStaticSerializedDataSeq, ConnextStaticSerializedData);
+ #undef ENABLE_TDATAREADER_DATA_CONSISTENCY_CHECK_METHOD
  
 +NDDSUSERDllExport
 +DDS_ReturnCode_t
@@ -116,6 +126,6 @@
 +  const char * type_name,
 +  struct DDS_TypeCode * type_code);
 +
- #if (defined(RTI_WIN32) || defined (RTI_WINCE)) && defined(NDDS_USER_DLL_EXPORT)
+ #if (defined(RTI_WIN32) || defined (RTI_WINCE) || defined(RTI_INTIME)) && defined(NDDS_USER_DLL_EXPORT)
  /* If the code is building on Windows, stop exporting symbols.
  */

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/ndds_include.hpp
@@ -17,6 +17,7 @@
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"


### PR DESCRIPTION
The patch file `connext_static_serialized_dataPlugin.cxx.patch` contains the heavy lifting and still needs to be updated (some parts present in the v5 patch file have been removed to allow compiling this patch against Connext 6).

Though this PR continues to work with Connext 5 and contains all the necessary logic to build with Connext 6 (minus the one remaining patch file to be updated).