### PR TITLE
CMAKE_SOURCE_DIR -> CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -134,7 +134,7 @@ set(patched_files
 )
 add_custom_command(
   OUTPUT ${patched_files}
-  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/bin/apply-patch.py" --input ${generated_files} --patch ${patch_files} --out ${patched_files}
+  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/bin/apply-patch.py" --input ${generated_files} --patch ${patch_files} --out ${patched_files}
   DEPENDS ${generated_files}
   COMMENT "Patching serialized type support for RTI Connext"
   VERBATIM


### PR DESCRIPTION
These will differ if this project is built as a sub-project of another cmake project, and in that case, CMAKE_CURRENT_SOURCE_DIR will point to the right place.

Signed-off-by: Dan Rose <dan@digilabs.io>