### PR TITLE
Add missing namespace to the list when getting node names

### DIFF
--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -99,6 +99,12 @@ get_node_names(
     final_ret = rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
     goto cleanup;
   }
+  tmp_namespaces_list.data[0] = rcutils_strdup(node->namespace_, allocator);
+  if (!tmp_namespaces_list.data[0]) {
+    RMW_SET_ERROR_MSG("could not allocate memory for a node namespace");
+    final_ret = rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
+    goto cleanup;
+  }
 
   for (auto i = 1; i < length; ++i) {
     DDS::ParticipantBuiltinTopicData pbtd;


### PR DESCRIPTION
Fixes a bug introduced in #362.

Addresses https://github.com/ros2/rmw_connext/pull/362#discussion_r367163984