### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rmw_connext_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_connext_cpp/src/rmw_service_server_is_available.cpp
@@ -171,9 +171,7 @@ rmw_service_server_is_available(
   fprintf(stderr, "response topic name: %s\n", response_topic_name);
   fprintf(stderr, "********\n");
   printf("Checking for service server:\n");
-  printf(" - %s: %zu\n",
-    request_topic_name,
-    number_of_request_subscribers);
+  printf(" - %s: %zu\n", request_topic_name, number_of_request_subscribers);
 #endif
   if (number_of_request_subscribers == 0) {
     // not ready
@@ -188,7 +186,8 @@ rmw_service_server_is_available(
     return ret;
   }
 #ifdef DISCOVERY_DEBUG_LOGGING
-  printf(" - %s: %zu\n",
+  printf(
+    " - %s: %zu\n",
     client_info->response_datareader_->get_topicdescription()->get_name(),
     number_of_response_publishers);
 #endif

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -311,9 +311,9 @@ rmw_take_serialized_message_with_info(
     return RMW_RET_ERROR;
   }
   DDS::InstanceHandle_t sending_publication_handle;
-  auto ret =
-    _take_serialized_message(subscription, serialized_message, taken,
-      &sending_publication_handle, allocation);
+  auto ret = _take_serialized_message(
+    subscription, serialized_message, taken,
+    &sending_publication_handle, allocation);
   if (ret != RMW_RET_OK) {
     // Error string is already set.
     return RMW_RET_ERROR;

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/topic_cache.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/topic_cache.hpp
@@ -117,8 +117,9 @@ public:
     const std::string & type_name)
   {
     initialize_participant_map(participant_to_topic_guids_, participant_guid);
-    if (rcutils_logging_logger_is_enabled_for("rmw_connext_shared_cpp",
-      RCUTILS_LOG_SEVERITY_DEBUG))
+    if (
+      rcutils_logging_logger_is_enabled_for(
+        "rmw_connext_shared_cpp", RCUTILS_LOG_SEVERITY_DEBUG))
     {
       std::stringstream guid_stream;
       guid_stream << participant_guid;

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
@@ -54,9 +54,9 @@ __gather_event_conditions(
       return RMW_RET_ERROR;
     }
     if (is_event_supported(current_event->event_type)) {
-      auto map_pair =
-        status_mask_map.insert(std::pair<DDS::StatusCondition *, DDS::StatusMask>(status_condition,
-          DDS::STATUS_MASK_NONE));
+      auto map_pair = status_mask_map.insert(
+        std::pair<DDS::StatusCondition *, DDS::StatusMask>(
+          status_condition, DDS::STATUS_MASK_NONE));
       auto iterator = map_pair.first;
       status_mask_map[status_condition] = get_status_kind_from_rmw(current_event->event_type) |
         (*iterator).second;

--- a/rmw_connext_shared_cpp/src/demangle.cpp
+++ b/rmw_connext_shared_cpp/src/demangle.cpp
@@ -82,7 +82,8 @@ _demangle_service_from_topic(const std::string & topic_name)
   auto suffix = suffixes[prefix];
   size_t suffix_position = topic_name.rfind(suffix);
   if (suffix_position == std::string::npos) {
-    RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
+    RCUTILS_LOG_WARN_NAMED(
+      "rmw_connext_shared_cpp",
       "service topic has prefix but no suffix"
       ", report this: '%s'", topic_name.c_str());
     return "";
@@ -113,7 +114,8 @@ _demangle_service_type_only(const std::string & dds_type_name)
     suffix_position = dds_type_name.rfind(suffix);
     if (suffix_position != std::string::npos) {
       if (dds_type_name.length() - suffix_position - suffix.length() != 0) {
-        RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_connext_shared_cpp",
           "service type contains 'dds_::' and a suffix, but not at the end"
           ", report this: '%s'", dds_type_name.c_str());
         continue;
@@ -123,7 +125,8 @@ _demangle_service_type_only(const std::string & dds_type_name)
     }
   }
   if (suffix_position == std::string::npos) {
-    RCUTILS_LOG_WARN_NAMED("rmw_connext_shared_cpp",
+    RCUTILS_LOG_WARN_NAMED(
+      "rmw_connext_shared_cpp",
       "service type contains 'dds_::' but does not have a suffix"
       ", report this: '%s'", dds_type_name.c_str());
     return "";

--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -85,9 +85,9 @@ create_node(
     return NULL;
   }
 
-  int written =
-    snprintf(reinterpret_cast<char *>(participant_qos.user_data.value.get_contiguous_buffer()),
-      length, "name=%s;namespace=%s;", name, namespace_);
+  int written = snprintf(
+    reinterpret_cast<char *>(participant_qos.user_data.value.get_contiguous_buffer()),
+    length, "name=%s;namespace=%s;", name, namespace_);
   if (written < 0 || written > static_cast<int>(length) - 1) {
     RMW_SET_ERROR_MSG("failed to populate user_data buffer");
     return NULL;

--- a/rmw_connext_shared_cpp/src/types/custom_data_reader_listener.cpp
+++ b/rmw_connext_shared_cpp/src/types/custom_data_reader_listener.cpp
@@ -45,7 +45,8 @@ void CustomDataReaderListener::add_information(
 #ifdef DISCOVERY_DEBUG_LOGGING
   std::stringstream ss;
   ss << participant_guid << ":" << guid;
-  printf("+%s %s %s <%s>\n",
+  printf(
+    "+%s %s %s <%s>\n",
     entity_type == EntityType::Publisher ? "P" : "S",
     ss.str().c_str(),
     topic_name.c_str(),
@@ -65,7 +66,8 @@ void CustomDataReaderListener::remove_information(
 #ifdef DISCOVERY_DEBUG_LOGGING
   std::stringstream ss;
   ss << guid;
-  printf("-%s %s\n",
+  printf(
+    "-%s %s\n",
     entity_type == EntityType::Publisher ? "P" : "S",
     ss.str().c_str());
 #endif


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.