### PR TITLE
finding rmw_connext_shared_cpp must succeed, only rmw_connext_cpp can signal not-found when Connext is not available

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -213,7 +213,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_package(CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake")
 
 install(
   DIRECTORY include/

--- a/rmw_connext_cpp/rmw_connext_cpp-extras.cmake
+++ b/rmw_connext_cpp/rmw_connext_cpp-extras.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
+# Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# copied from rmw_connext_shared_cpp/rmw_connext_shared_cpp-extras.cmake
-
-include(
-  "${rmw_connext_shared_cpp_DIR}/get_rmw_connext_output_filter.cmake")
-
 find_package(connext_cmake_module QUIET)
 find_package(Connext MODULE QUIET)
 
-if(Connext_FOUND)
-  list(APPEND rmw_connext_shared_cpp_DEFINITIONS ${Connext_DEFINITIONS})
-  list(APPEND rmw_connext_shared_cpp_INCLUDE_DIRS ${Connext_INCLUDE_DIRS})
-  list(APPEND rmw_connext_shared_cpp_LIBRARIES ${Connext_LIBRARIES})
+if(NOT Connext_FOUND)
+  message(STATUS
+    "Could not find RTI Connext - skipping rmw_connext_cpp")
+  set(rmw_connext_cpp_FOUND FALSE)
 endif()


### PR DESCRIPTION
Fixes #388 which was introduced by #385.

The CI builds won't show the specific problem or if it was resolved. Therefore only a single sanity check on Linux: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9263)](https://ci.ros2.org/job/ci_linux/9263/)

Packaging build to try the archive: https://ci.ros2.org/job/ci_packaging_linux/294/