### PR TITLE
Don't use RTPS Participant name as node name

### DIFF
--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -127,13 +127,6 @@ get_node_names(
       if (ns_found != map.end()) {
         namespace_ = std::string(ns_found->second.begin(), ns_found->second.end());
       }
-
-      if (name.empty()) {
-        // use participant name if no name was found in the user data
-        if (pbtd.participant_name.name) {
-          name = pbtd.participant_name.name;
-        }
-      }
     }
 
     // ignore discovered participants without a name


### PR DESCRIPTION
This is what I mentioned here: https://github.com/ros2/ros2cli/pull/464#issuecomment-594764745.

Currently, the node name and namespace are communicated making use of `userData` qos.
In case that that qos setting can be parsed in the way ros2 is using it, we're using the RTPS Participant name as a node name, and listing it.

The question is: is that exactly what we want?
I see some value of showing the user other `Participants` that weren't craeted with ROS, but probably, their name should be showed with a different prefix. An opt-in/opt-out flag to show them or not would also be nice.

In https://github.com/ros2/rmw_fastrtps/pull/312, `userData` is now being use to communicate the `Context` name. Connext was failing to parse it, and then showing the RTPS Participant name.

We can take the following paths:
- Just show `Participants` that their `userData` can be parsed correctly (proposed in this PR).
- Don't change anything here, and accept the participant name to be showed as a node name. Make sure that the tests don't run nodes from a different implementation when they shouldn't (see https://github.com/ros2/ros2cli/pull/464).

I don't know what's the best option, @hidmic @wjwwood opinions?