### PR TITLE
Increase the max_objects_per_thread.

### DIFF
--- a/rmw_connext_shared_cpp/src/init.cpp
+++ b/rmw_connext_shared_cpp/src/init.cpp
@@ -25,5 +25,10 @@ init()
     RMW_SET_ERROR_MSG("failed to get participant factory");
     return RMW_RET_ERROR;
   }
+
+  DDS::DomainParticipantFactoryQos factory_qos;
+  dpf_->get_qos(factory_qos);
+  factory_qos.resource_limits.max_objects_per_thread = 8192;
+  dpf_->set_qos(factory_qos);
   return RMW_RET_OK;
 }


### PR DESCRIPTION
The default is 1024, which allows about 11 participants.
According to the documentation at
https://community.rti.com/kb/how-many-domain-participants-can-be-created-single-address-space ,
2048 allows about 30.  Based on empirical evidence, we increase
to 8192, which should allow something like 60 - 70 participants.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>