### PR TITLE
Fix build warnings due to -Wsign-compare with GCC 9

### DIFF
--- a/rmw_connext_cpp/src/rmw_publish.cpp
+++ b/rmw_connext_cpp/src/rmw_publish.cpp
@@ -43,7 +43,7 @@ publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_str
   DDS::ReturnCode_t status = DDS::RETCODE_ERROR;
 
   instance->serialized_data.maximum(0);
-  if (cdr_stream->buffer_length > (std::numeric_limits<DDS_Long>::max)()) {
+  if (cdr_stream->buffer_length > static_cast<size_t>((std::numeric_limits<DDS_Long>::max)())) {
     RMW_SET_ERROR_MSG("cdr_stream->buffer_length unexpectedly larger than DDS_Long's max value");
     return false;
   }

--- a/rmw_connext_shared_cpp/src/qos.cpp
+++ b/rmw_connext_shared_cpp/src/qos.cpp
@@ -118,7 +118,7 @@ set_entity_qos_from_profile_generic(
     entity_qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS &&
     static_cast<size_t>(entity_qos.history.depth) < qos_profile.depth)
   {
-    if (qos_profile.depth > (std::numeric_limits<DDS::Long>::max)()) {
+    if (qos_profile.depth > static_cast<size_t>((std::numeric_limits<DDS::Long>::max)())) {
       RMW_SET_ERROR_MSG(
         "failed to set history depth since the requested queue size exceeds the DDS type");
       return false;


### PR DESCRIPTION
These are appearing on our Ubuntu Focal builds, e.g. http://build.ros2.org/view/Fci/job/Fci__nightly-connext_ubuntu_focal_amd64/50/warnings24Result/