### PR TITLE
Correct error message when using a non supported event

### DIFF
--- a/rmw_connext_shared_cpp/src/event.cpp
+++ b/rmw_connext_shared_cpp/src/event.cpp
@@ -38,7 +38,7 @@ __rmw_init_event(
     identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   if (!is_event_supported(event_type)) {
-    RMW_SET_ERROR_MSG("provided event_type is not supported by rmw_fastrtps_cpp");
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("provided event_type is not supported by %s", identifier);
     return RMW_RET_UNSUPPORTED;
   }
 


### PR DESCRIPTION
Follow up of https://github.com/ros2/rmw_connext/pull/397.