### PR TITLE
Fixed connext_static_serialized_dataPlugin.h.patch

### DIFF
--- a/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.h.patch
+++ b/rmw_connext_cpp/resources/patch_files/connext_static_serialized_dataPlugin.h.patch
@@ -1,11 +1,11 @@
 --- a/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
 +++ b/rmw_connext_cpp/resources/patch_generated/connext_static_serialized_dataPlugin.h
-@@ -324,6 +324,9 @@ extern "C" {
-     NDDSUSERDllExport extern struct PRESTypePlugin*
-     ConnextStaticSerializedDataPlugin_new(void);
- 
-+    NDDSUSERDllExport extern struct PRESTypePlugin*
-+    ConnextStaticSerializedDataPlugin_new_external(struct DDS_TypeCode * external_type_code);
+@@ -322,6 +322,9 @@
+ NDDSUSERDllExport extern struct PRESTypePlugin*
+ ConnextStaticSerializedDataPlugin_new(void);
+
++NDDSUSERDllExport extern struct PRESTypePlugin*
++ConnextStaticSerializedDataPlugin_new_external(struct DDS_TypeCode * external_type_code);
 +
-     NDDSUSERDllExport extern void
-     ConnextStaticSerializedDataPlugin_delete(struct PRESTypePlugin *);
+ NDDSUSERDllExport extern void
+ ConnextStaticSerializedDataPlugin_delete(struct PRESTypePlugin *);


### PR DESCRIPTION
For some reason this failure has appeared in the buildfarm https://ci.ros2.org/job/ci_linux/9920/console:

```
16:55:26 Traceback (most recent call last):
16:55:26   File "/home/jenkins-agent/workspace/ci_linux/ws/src/ros2/rmw_connext/rmw_connext_cpp/bin/apply-patch.py", line 80, in <module>
16:55:26     content_out = apply_patch(content_in, content_patch)
16:55:26   File "/home/jenkins-agent/workspace/ci_linux/ws/src/ros2/rmw_connext/rmw_connext_cpp/bin/apply-patch.py", line 60, in apply_patch
16:55:26     assert s[sl] == line[1:], \
16:55:26 AssertionError: s[323] '
16:55:26 ' != line[1:] '    NDDSUSERDllExport extern struct PRESTypePlugin*
16:55:26 '
 ```

Signed-off-by: ahcorde <ahcorde@gmail.com>