### PR TITLE
Do not force 510 locators compatibility mode

### DIFF
--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -116,15 +116,6 @@ create_node(
     RMW_SET_ERROR_MSG("failed to add qos property");
     return NULL;
   }
-  status = DDS::PropertyQosPolicyHelper::add_property(
-    participant_qos.property,
-    "dds.transport.use_510_compatible_locator_kinds",
-    "1",
-    DDS::BOOLEAN_FALSE);
-  if (status != DDS::RETCODE_OK) {
-    RMW_SET_ERROR_MSG("failed to add qos property");
-    return NULL;
-  }
 
   // Disable TypeCode since it increases discovery message size and is replaced by TypeObject
   // https://community.rti.com/kb/types-matching


### PR DESCRIPTION
Stop using Connext 5.1 locator kinds compatibility mode.

See:
- https://community.rti.com/static/documentation/connext-dds/5.2.0/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_ReleaseNotes/Content/ReleaseNotes/Transport_Compatibility.htm
- https://github.com/ros2/ros2_documentation/pull/592/files