### PR TITLE
fix CMake warning about using uninitialized variables

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.5)
 project(rmw_connext_cpp)
 
 if(DEFINED ENV{CONNEXT_STATIC_DISABLE})
-  set(disable $ENV{CONNEXT_STATIC_DISABLE})
+  set(disable_static_connext $ENV{CONNEXT_STATIC_DISABLE})
 else()
-  set(disable FALSE)
+  set(disable_static_connext FALSE)
 endif()
-set(CONNEXT_STATIC_DISABLE ${disable}
+set(CONNEXT_STATIC_DISABLE ${disable_static_connext}
   CACHE BOOL "If Connext Static should be disabled.")
 
 # Default to C++14

--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmw_connext_cpp)
 
-set(CONNEXT_STATIC_DISABLE $ENV{CONNEXT_STATIC_DISABLE}
+if(DEFINED ENV{CONNEXT_STATIC_DISABLE})
+  set(disable $ENV{CONNEXT_STATIC_DISABLE})
+else()
+  set(disable FALSE)
+endif()
+set(CONNEXT_STATIC_DISABLE ${disable}
   CACHE BOOL "If Connext Static should be disabled.")
 
 # Default to C++14


### PR DESCRIPTION
When invoking CMake with `--warn-uninitialized`.