### PR TITLE
More verbose error output when apply_patch.py fails

### DIFF
--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -18,6 +18,7 @@
 
 import argparse
 import re
+import sys
 
 # regular expression / pattern for patch header
 _hdr_pat = re.compile(r'^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@.*$')
@@ -79,7 +80,7 @@ for i, p, o in zip(args.input, args.patch, args.out):
     try:
         content_out = apply_patch(content_in, content_patch)
     except Exception:
-        print(i, p, o)
+        print(i, p, o, file=sys.stderr)
         raise
     with open(o, 'w') as h:
         h.write(content_out)

--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -84,12 +84,12 @@ for i, p, o in zip(args.input, args.patch, args.out):
             f'Failed to generate "{o}" using input "{i}" and patch "{p}"',
             file=sys.stderr,
         )
-        print('---------input file---------' , file=sys.stderr)
+        print('---------input file---------', file=sys.stderr)
         print(content_in, file=sys.stderr)
-        print('----------------------------' , file=sys.stderr)
-        print('---------patch file---------' , file=sys.stderr)
+        print('----------------------------', file=sys.stderr)
+        print('---------patch file---------', file=sys.stderr)
         print(content_patch, file=sys.stderr)
-        print('----------------------------' , file=sys.stderr)
+        print('----------------------------', file=sys.stderr)
         raise
     with open(o, 'w') as h:
         h.write(content_out)

--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -81,6 +81,12 @@ for i, p, o in zip(args.input, args.patch, args.out):
         content_out = apply_patch(content_in, content_patch)
     except Exception:
         print(i, p, o, file=sys.stderr)
+        print('---------input file---------' , file=sys.stderr)
+        print(content_in, file=sys.stderr)
+        print('----------------------------' , file=sys.stderr)
+        print('---------patch file---------' , file=sys.stderr)
+        print(content_patch, file=sys.stderr)
+        print('----------------------------' , file=sys.stderr)
         raise
     with open(o, 'w') as h:
         h.write(content_out)

--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -80,7 +80,10 @@ for i, p, o in zip(args.input, args.patch, args.out):
     try:
         content_out = apply_patch(content_in, content_patch)
     except Exception:
-        print(i, p, o, file=sys.stderr)
+        print(
+            f'input file path: "{i}", patch file path: "{p}", output file path: "{o}"',
+            file=sys.stderr,
+        )
         print('---------input file---------' , file=sys.stderr)
         print(content_in, file=sys.stderr)
         print('----------------------------' , file=sys.stderr)

--- a/rmw_connext_cpp/bin/apply-patch.py
+++ b/rmw_connext_cpp/bin/apply-patch.py
@@ -81,7 +81,7 @@ for i, p, o in zip(args.input, args.patch, args.out):
         content_out = apply_patch(content_in, content_patch)
     except Exception:
         print(
-            f'input file path: "{i}", patch file path: "{p}", output file path: "{o}"',
+            f'Failed to generate "{o}" using input "{i}" and patch "{p}"',
             file=sys.stderr,
         )
         print('---------input file---------' , file=sys.stderr)


### PR DESCRIPTION
See https://github.com/ros2/build_farmer/issues/273 for more context.

From https://ci.ros2.org/job/ci_linux/10475/console#console-section-26, it seems that `connext_static_serialized_dataPlugin.h.patch` is being applied to `connext_static_serialized_data.cxx` ... which would be wrong.

The line that would confirm that isn't being shown in the logs, and I think it's because the message is being printed in `stdout`.