### PR TITLE
Retry calling the idl_pp up to 10 times.

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -93,7 +93,7 @@ set(generated_files
 )
 add_custom_command(
   OUTPUT ${generated_files}
-  COMMAND "${_idl_pp}" -language C++ -unboundedSupport "connext_static_serialized_data.idl" -d ${generated_directory}
+  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/bin/call-idl-pp.py" --idl-pp ${_idl_pp} --idl-file "connext_static_serialized_data.idl" -d ${generated_directory}
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources"
   COMMENT "Generating serialized type support for RTI Connext (using '${_idl_pp}')"
   VERBATIM

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -1,0 +1,47 @@
+# This is a utility function to help generate consistent results from Connext rtiddsgen{_server}.
+# We've seen cases where it can generate header files that do not contain the proper 'extern "C"'
+# markings, which we believe is a race inside the generator itself.
+# To combat this, we try up to 10 times to generate, and ensure that the header files have the
+# correct markings.  Once they do, we consider it a success.
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--idl-pp', required=True)
+    parser.add_argument('--idl-file', required=True)
+    parser.add_argument('-d', required=True)
+    parser.add_argument('--max-tries', type=int, default=10)
+    args = parser.parse_args()
+
+    done = False
+    count = 0
+    while not done and count < args.max_tries:
+        # Remove and recreate the output target directory.  This ensures that previous failed
+        # attempts won't cause the next attempt to fail.
+        try:
+            shutil.rmtree(args.d)
+        except FileNotFoundError:
+            pass
+        os.mkdir(args.d)
+
+        ret = subprocess.run(args=[args.idl_pp, "-language", "C++", "-unboundedSupport", args.idl_file, "-d", args.d])
+        if ret.returncode == 0:
+            with open(os.path.join(args.d, args.idl_file[:-4] + 'Plugin.h'), 'r') as infp:
+                for line in infp:
+                    if line.startswith('extern "C" {'):
+                        done = True
+                        break
+        count += 1
+
+    if count == args.max_tries:
+        print('Could not successfully generate Connext serialized data', file=sys.stderr)
+        return 1
+    return ret.returncode
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -50,7 +50,7 @@ def main():
             with open(os.path.join(args.d, args.idl_file[:-4] + 'Plugin.h'), 'r') as infp:
                 for line in infp:
                     if line.startswith('extern "C" {'):
-                        return ret.returncode
+                        return 0
 
         print(f'Try {count} of {args.max_tries} failed to generate header with \'extern "C"\'',
               end='')

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -1,14 +1,30 @@
-# This is a utility function to help generate consistent results from Connext rtiddsgen{_server}.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a utility program to help generate consistent results from Connext rtiddsgen{_server}.
 # We've seen cases where it can generate header files that do not contain the proper 'extern "C"'
 # markings, which we believe is a race inside the generator itself.
 # To combat this, we try up to 10 times to generate, and ensure that the header files have the
-# correct markings.  Once they do, we consider it a success.
+# correct markings.
+# Once they do, we consider it a success.
 
 import argparse
 import os
 import shutil
 import subprocess
 import sys
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -18,9 +34,8 @@ def main():
     parser.add_argument('--max-tries', type=int, default=10)
     args = parser.parse_args()
 
-    done = False
-    count = 0
-    while not done and count < args.max_tries:
+    count = 1
+    while count <= args.max_tries:
         # Remove and recreate the output target directory.  This ensures that previous failed
         # attempts won't cause the next attempt to fail.
         try:
@@ -29,19 +44,26 @@ def main():
             pass
         os.mkdir(args.d)
 
-        ret = subprocess.run(args=[args.idl_pp, "-language", "C++", "-unboundedSupport", args.idl_file, "-d", args.d])
+        ret = subprocess.run(args=[args.idl_pp, '-language', 'C++', '-unboundedSupport',
+                                   args.idl_file, '-d', args.d])
         if ret.returncode == 0:
             with open(os.path.join(args.d, args.idl_file[:-4] + 'Plugin.h'), 'r') as infp:
                 for line in infp:
                     if line.startswith('extern "C" {'):
-                        done = True
-                        break
+                        return ret.returncode
+
+        print(f'Try {count} of {args.max_tries} failed to generate header with \'extern "C"\'',
+              end='')
         count += 1
+        if count <= args.max_tries:
+            print(', trying again')
+        else:
+            print(', giving up')
 
-    if count == args.max_tries:
-        print('Could not successfully generate Connext serialized data', file=sys.stderr)
-        return 1
-    return ret.returncode
+    sys.stdout.flush()
+    print('Could not successfully generate Connext serialized data', file=sys.stderr)
+    return 1
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
This is because of possible races in rtiddsgen_server.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

In theory this will mitigate the problems investigated in https://github.com/ros2/build_farmer/issues/273 .  However, since we don't have a reliable reproducer, we are just going to have to try it out and see if it helps.

One additional thing that we may want to do is forcefully kill off `rtiddsgen_server` before trying again.  However, we:

1.  Don't have proof that that is necessary, and
1.  I don't know a good cross-platform way to do that

So I think this is a good start for now.