### PR TITLE
Cast size_t to DDS_Long explicitly.

### DIFF
--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -283,7 +283,7 @@ _take_sequence(
   DDS::ReturnCode_t status = data_reader->take(
     dds_messages,
     sample_infos,
-    count,
+    static_cast<DDS_Long>(count),
     DDS::ANY_SAMPLE_STATE,
     DDS::ANY_VIEW_STATE,
     DDS::ANY_INSTANCE_STATE);

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -248,6 +248,13 @@ _take_sequence(
     return RMW_RET_ERROR;
   }
 
+  if (count > std::numeric_limits<DDS_Long>::max()) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "cannot take %ld samples at once, limit is %d",
+      count, std::numeric_limits<DDS_Long>::max());
+    return RMW_RET_ERROR;
+  }
+
   ConnextStaticSubscriberInfo * subscriber_info =
     static_cast<ConnextStaticSubscriberInfo *>(subscription->data);
   if (!subscriber_info) {

--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -248,10 +248,10 @@ _take_sequence(
     return RMW_RET_ERROR;
   }
 
-  if (count > std::numeric_limits<DDS_Long>::max()) {
+  if (count > (std::numeric_limits<DDS_Long>::max)()) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "cannot take %ld samples at once, limit is %d",
-      count, std::numeric_limits<DDS_Long>::max());
+      count, (std::numeric_limits<DDS_Long>::max)());
     return RMW_RET_ERROR;
   }
 


### PR DESCRIPTION
This pull request aims to fix [a warning seen on nightly Windows builds](https://ci.ros2.org/view/nightly/job/nightly_win_rel/1533/msbuild/category.63474818/). Said warning was introduced by https://github.com/ros2/rmw_connext/pull/408. This was first observed when running CI for [ros2/launch#408](https://github.com/ros2/launch/pull/408#issuecomment-620162001). 


CI up to `rmw_connext` and `rmw_cyclonedds_cpp`:
- Windows [![Build Status](https://ci.ros2.org/job/ci_windows/10425/badge/icon)](https://ci.ros2.org/job/ci_windows/10425/) 