### PR TITLE
Correct rmw_take() return value.

### DIFF
--- a/rmw_connext_cpp/src/rmw_take.cpp
+++ b/rmw_connext_cpp/src/rmw_take.cpp
@@ -280,7 +280,7 @@ _take_sequence(
     ConnextStaticSerializedDataDataReader::narrow(topic_reader);
   if (!data_reader) {
     RMW_SET_ERROR_MSG("failed to narrow data reader");
-    return false;
+    return RMW_RET_ERROR;
   }
 
   ConnextStaticSerializedDataSeq dds_messages;


### PR DESCRIPTION
A tiny fix. I believe this was introduced in #408, and compilers implicitly casted a `bool` literal into an `rmw_ret_t` value.