### PR TITLE
Switch to always using rtiddsgen (not the server).

### DIFF
--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -87,9 +87,10 @@ set(generated_files
 )
 add_custom_command(
   OUTPUT ${generated_files}
-  # We *explicitly* do not use Connext_DDSGEN_SERVER here.  That's so that we don't
-  # accidentally connect to another version of the server that might still be running
-  # from previous runs in rosidl_typesupport_connext_cpp.
+  # We *explicitly* do not use Connext_DDSGEN_SERVER here.  The other time we invoke the
+  # server is in rosidl_typesupport_connext_cpp, and that uses a different set of arguments.
+  # We don't want to accidentally connect to that other version of the server that might
+  # still be running.
   COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/bin/call-idl-pp.py" --idl-pp "${Connext_DDSGEN}" --idl-file "connext_static_serialized_data.idl" -d ${generated_directory}
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources"
   COMMENT "Generating serialized type support for RTI Connext (using '${Connext_DDSGEN}')"

--- a/rmw_connext_cpp/CMakeLists.txt
+++ b/rmw_connext_cpp/CMakeLists.txt
@@ -75,12 +75,6 @@ register_rmw_implementation(
 )
 
 # generate code for raw data
-set(_idl_pp "${Connext_DDSGEN}")
-if(NOT "${Connext_DDSGEN_SERVER}" STREQUAL "")
-  # use the code generator in server mode when available
-  # because it speeds up the code generation step significantly
-  set(_idl_pp "${Connext_DDSGEN_SERVER}")
-endif()
 set(generated_directory "${CMAKE_CURRENT_BINARY_DIR}/resources/generated")
 file(MAKE_DIRECTORY ${generated_directory})
 set(generated_files
@@ -93,9 +87,12 @@ set(generated_files
 )
 add_custom_command(
   OUTPUT ${generated_files}
-  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/bin/call-idl-pp.py" --idl-pp ${_idl_pp} --idl-file "connext_static_serialized_data.idl" -d ${generated_directory}
+  # We *explicitly* do not use Connext_DDSGEN_SERVER here.  That's so that we don't
+  # accidentally connect to another version of the server that might still be running
+  # from previous runs in rosidl_typesupport_connext_cpp.
+  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/bin/call-idl-pp.py" --idl-pp "${Connext_DDSGEN}" --idl-file "connext_static_serialized_data.idl" -d ${generated_directory}
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources"
-  COMMENT "Generating serialized type support for RTI Connext (using '${_idl_pp}')"
+  COMMENT "Generating serialized type support for RTI Connext (using '${Connext_DDSGEN}')"
   VERBATIM
 )
 

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -44,8 +44,9 @@ def main():
             pass
         os.mkdir(args.d)
 
-        ret = subprocess.run(args=[args.idl_pp, '-language', 'C++', '-unboundedSupport',
-                                   args.idl_file, '-d', args.d])
+        cmdline = [args.idl_pp, '-language', 'C++', '-unboundedSupport', args.idl_file, '-d', args.d]
+        print('Running command: %s' % (' '.join(cmdline)))
+        ret = subprocess.run(args=cmdline)
         if ret.returncode == 0:
             with open(os.path.join(args.d, args.idl_file[:-4] + 'Plugin.h'), 'r') as infp:
                 for line in infp:

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -44,8 +44,9 @@ def main():
             pass
         os.mkdir(args.d)
 
-        cmdline = [args.idl_pp, '-language', 'C++', '-unboundedSupport', args.idl_file, '-d',
-                   args.d]
+        cmdline = [
+            args.idl_pp, '-language', 'C++', '-unboundedSupport', args.idl_file, '-d', args.d
+        ]
         print('Running command: %s' % (' '.join(cmdline)))
         ret = subprocess.run(args=cmdline)
         if ret.returncode == 0:

--- a/rmw_connext_cpp/bin/call-idl-pp.py
+++ b/rmw_connext_cpp/bin/call-idl-pp.py
@@ -44,7 +44,8 @@ def main():
             pass
         os.mkdir(args.d)
 
-        cmdline = [args.idl_pp, '-language', 'C++', '-unboundedSupport', args.idl_file, '-d', args.d]
+        cmdline = [args.idl_pp, '-language', 'C++', '-unboundedSupport', args.idl_file, '-d',
+                   args.d]
         print('Running command: %s' % (' '.join(cmdline)))
         ret = subprocess.run(args=cmdline)
         if ret.returncode == 0:


### PR DESCRIPTION
This is to avoid potential problems where we could connect
to an earlier iteration of the server, and generate things
we do not expect.  Since we know we are only ever generating
one IDL, we just use the normal rtiddsgen and then use the
server for generating "everything else".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>