### PR TITLE
Finalize context if and only if it's shutdown

### DIFF
--- a/rmw_connext_cpp/src/rmw_init.cpp
+++ b/rmw_connext_cpp/src/rmw_init.cpp
@@ -21,7 +21,8 @@
 
 #include "rmw_connext_cpp/identifier.hpp"
 
-struct rmw_context_impl_t {
+struct rmw_context_impl_t
+{
   // Shutdown flag
   bool is_shutdown{false};
 };


### PR DESCRIPTION
This pull request, albeit controversial, ensures `rmw_context_fini()` fails on a not shutdown context, as its API contract establishes (see https://github.com/ros2/rmw/pull/242).