### PR TITLE
Avoid leaking DDS::Topic objects

### DIFF
--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_publisher_info.hpp
@@ -36,6 +36,7 @@ struct ConnextStaticPublisherInfo : ConnextCustomEventInfo
   DDS::Publisher * dds_publisher_;
   ConnextPublisherListener * listener_;
   DDS::DataWriter * topic_writer_;
+  DDS::Topic * topic_;
   const message_type_support_callbacks_t * callbacks_;
   rmw_gid_t publisher_gid;
 

--- a/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
+++ b/rmw_connext_cpp/include/rmw_connext_cpp/connext_static_subscriber_info.hpp
@@ -35,6 +35,7 @@ struct ConnextStaticSubscriberInfo : ConnextCustomEventInfo
   DDS::Subscriber * dds_subscriber_;
   ConnextSubscriberListener * listener_;
   DDS::DataReader * topic_reader_;
+  DDS::Topic * topic_;
   DDS::ReadCondition * read_condition_;
   const message_type_support_callbacks_t * callbacks_;
   /// Remap the specific RTI Connext DDS DataReader Status to a generic RMW status type.

--- a/rmw_connext_shared_cpp/src/create_topic.cpp
+++ b/rmw_connext_shared_cpp/src/create_topic.cpp
@@ -40,6 +40,7 @@ rmw_connext_shared_cpp::create_topic(
 
   std::lock_guard<std::mutex> guard(node_info->topic_creation_mutex);
 
+  // This functions returns a copy, that has to be destroyed independently.
   DDS::Topic * topic = participant->find_topic(dds_topic_name, DDS::Duration_t::from_seconds(0));
   if (!topic) {
     DDS::TopicQos default_topic_qos;

--- a/rmw_connext_shared_cpp/src/create_topic.cpp
+++ b/rmw_connext_shared_cpp/src/create_topic.cpp
@@ -40,8 +40,7 @@ rmw_connext_shared_cpp::create_topic(
 
   std::lock_guard<std::mutex> guard(node_info->topic_creation_mutex);
 
-  DDS::Duration_t timeout = DDS::Duration_t::from_seconds(0);
-  DDS::Topic * topic = participant->find_topic(dds_topic_name, timeout);
+  DDS::Topic * topic = participant->find_topic(dds_topic_name, DDS::Duration_t::from_seconds(0));
   if (!topic) {
     DDS::TopicQos default_topic_qos;
     DDS::ReturnCode_t status = participant->get_default_topic_qos(default_topic_qos);

--- a/rmw_connext_shared_cpp/src/create_topic.cpp
+++ b/rmw_connext_shared_cpp/src/create_topic.cpp
@@ -40,7 +40,7 @@ rmw_connext_shared_cpp::create_topic(
 
   std::lock_guard<std::mutex> guard(node_info->topic_creation_mutex);
 
-  // This functions returns a copy, that has to be destroyed independently.
+  // This function returns a copy that has to be destroyed independently.
   DDS::Topic * topic = participant->find_topic(dds_topic_name, DDS::Duration_t::from_seconds(0));
   if (!topic) {
     DDS::TopicQos default_topic_qos;

--- a/rmw_connext_shared_cpp/src/create_topic.cpp
+++ b/rmw_connext_shared_cpp/src/create_topic.cpp
@@ -40,14 +40,11 @@ rmw_connext_shared_cpp::create_topic(
 
   std::lock_guard<std::mutex> guard(node_info->topic_creation_mutex);
 
-  DDS::TopicDescription * topic_description =
-    participant->lookup_topicdescription(dds_topic_name);
-
-  DDS::Topic * topic = nullptr;
-  DDS::ReturnCode_t status = DDS::RETCODE_ERROR;
-  if (!topic_description) {
+  DDS::Duration_t timeout = DDS::Duration_t::from_seconds(0);
+  DDS::Topic * topic = participant->find_topic(dds_topic_name, timeout);
+  if (!topic) {
     DDS::TopicQos default_topic_qos;
-    status = participant->get_default_topic_qos(default_topic_qos);
+    DDS::ReturnCode_t status = participant->get_default_topic_qos(default_topic_qos);
     if (status != DDS::RETCODE_OK) {
       RMW_SET_ERROR_MSG("failed to get default topic qos");
       return nullptr;
@@ -59,15 +56,6 @@ rmw_connext_shared_cpp::create_topic(
     if (!topic) {
       RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
         "failed to create topic '%s' for node namespace='%s' name='%s'",
-        topic_name, node->namespace_, node->name);
-      return nullptr;
-    }
-  } else {
-    DDS::Duration_t timeout = DDS::Duration_t::from_seconds(0);
-    topic = participant->find_topic(dds_topic_name, timeout);
-    if (!topic) {
-      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "failed to find topic '%s' for node namespace='%s' name='%s'",
         topic_name, node->namespace_, node->name);
       return nullptr;
     }

--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -477,7 +477,7 @@ destroy_node(const char * implementation_identifier, rmw_node_t * node)
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
 
-  // This unregisters types and destroys topics which were shared between
+  // This unregisters types which were shared between
   // publishers and subscribers and could not be cleaned up in the delete functions.
   if (participant->delete_contained_entities() == DDS::RETCODE_OK) {
     DDS::DomainParticipantFactory * dpf_ = DDS::DomainParticipantFactory::get_instance();


### PR DESCRIPTION
Follow up of https://github.com/ros2/rmw_connext/pull/442.

Based on [find_topic](https://community.rti.com/static/documentation/connext-dds/5.3.1/doc/api/connext_dds/api_cpp/classDDSDomainParticipant.html#a4495ca19a7c63f82c21a4f07c8200cd9) documentation, it returns a object that can be independently destroyed and not a reference to the one found.

This PR modifies publisher/subscription creation and destruction, so that the `DDS::Topic` objects are destroyed as soon as possible (i.e. when destroying a publisher/subscription).

For example, an application that creates and destroy a publisher on the same topic repeatedly was increasingly allocating more resources. This PR avoids that.

I've also simplified topic creation code, as using both `find_topic` and [lookup_topic_descritpion](https://community.rti.com/static/documentation/connext-dds/5.3.1/doc/api/connext_dds/api_cpp/classDDSDomainParticipant.html#a33b285799bcc1f5383ff990f3c43a1db) is redundant.

This passes `rcl` tests correctly locally, but it deserves full CI before being merged.

---

Publisher and Subscriptions are still leaking the "registered type", but that's much more complex to fix because we're using undocumented rti functions :confused:.