### PR TITLE
2.3.0

### DIFF
--- a/rmw_connext_cpp/CHANGELOG.rst
+++ b/rmw_connext_cpp/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmw_connext_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.3.0 (2020-07-30)
+------------------
 * Ensure compliant publisher API (`#445 <https://github.com/ros2/rmw_connext/issues/445>`_)
 * Avoid leaking DDS::Topic objects (`#444 <https://github.com/ros2/rmw_connext/issues/444>`_)
 * Contributors: Ivan Santiago Paunovic, Michel Hidalgo

--- a/rmw_connext_cpp/CHANGELOG.rst
+++ b/rmw_connext_cpp/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_connext_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Ensure compliant publisher API (`#445 <https://github.com/ros2/rmw_connext/issues/445>`_)
+* Avoid leaking DDS::Topic objects (`#444 <https://github.com/ros2/rmw_connext/issues/444>`_)
+* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
+
 2.2.0 (2020-07-22)
 ------------------
 * Set context actual domain id (`#443 <https://github.com/ros2/rmw_connext/issues/443>`_)

--- a/rmw_connext_cpp/package.xml
+++ b/rmw_connext_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_connext_cpp</name>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
   <description>Implement the ROS middleware interface using RTI Connext static code generation in C++.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>

--- a/rmw_connext_shared_cpp/CHANGELOG.rst
+++ b/rmw_connext_shared_cpp/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package rmw_connext_shared_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.3.0 (2020-07-30)
+------------------
 * Ensure compliant publisher API (`#445 <https://github.com/ros2/rmw_connext/issues/445>`_)
 * Avoid leaking DDS::Topic objects (`#444 <https://github.com/ros2/rmw_connext/issues/444>`_)
 * Contributors: Ivan Santiago Paunovic, Michel Hidalgo

--- a/rmw_connext_shared_cpp/CHANGELOG.rst
+++ b/rmw_connext_shared_cpp/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_connext_shared_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Ensure compliant publisher API (`#445 <https://github.com/ros2/rmw_connext/issues/445>`_)
+* Avoid leaking DDS::Topic objects (`#444 <https://github.com/ros2/rmw_connext/issues/444>`_)
+* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
+
 2.2.0 (2020-07-22)
 ------------------
 * Set context actual domain id (`#443 <https://github.com/ros2/rmw_connext/issues/443>`_)

--- a/rmw_connext_shared_cpp/package.xml
+++ b/rmw_connext_shared_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rmw_connext_shared_cpp</name>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
   <description>C++ types and functions shared by the ROS middleware interface to RTI Connext Static and RTI Connext Dynamic.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
I'm opening this for debate.

I think this is a minor bump because, even though #444 changed some public structs' binary layouts, those structs are not actually part of the package's API (there's actually no reason for them to be in publicly installed headers).