### PR TITLE
Revert "Ensure compliant publisher API (#445)"

### DIFF
--- a/rmw_connext_cpp/src/rmw_publisher.cpp
+++ b/rmw_connext_cpp/src/rmw_publisher.cpp
@@ -16,11 +16,9 @@
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
-#include "rmw/validate_full_topic_name.h"
-
-#include "rmw/impl/cpp/macros.hpp"
 
 #include "rmw_connext_shared_cpp/create_topic.hpp"
 #include "rmw_connext_shared_cpp/qos.hpp"
@@ -73,38 +71,49 @@ rmw_create_publisher(
   const rmw_qos_profile_t * qos_profile,
   const rmw_publisher_options_t * publisher_options)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+  if (!node) {
+    RMW_SET_ERROR_MSG("node handle is null");
+    return NULL;
+  }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node handle,
-    node->implementation_identifier,
-    rti_connext_identifier,
-    return nullptr);
-  RMW_CONNEXT_EXTRACT_MESSAGE_TYPESUPPORT(type_supports, type_support, nullptr);
-  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, nullptr);
-  if (0 == strlen(topic_name)) {
-    RMW_SET_ERROR_MSG("topic_name argument is an empty string");
-    return nullptr;
+    node->implementation_identifier, rti_connext_identifier,
+    return NULL)
+
+  RMW_CONNEXT_EXTRACT_MESSAGE_TYPESUPPORT(type_supports, type_support, NULL)
+
+  if (!topic_name || strlen(topic_name) == 0) {
+    RMW_SET_ERROR_MSG("publisher topic is null or empty string");
+    return NULL;
   }
-  RMW_CHECK_ARGUMENT_FOR_NULL(qos_profile, nullptr);
-  if (!qos_profile->avoid_ros_namespace_conventions) {
-    int validation_result = RMW_TOPIC_VALID;
-    rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, nullptr);
-    if (RMW_RET_OK != ret) {
-      return nullptr;
-    }
-    if (RMW_TOPIC_VALID != validation_result) {
-      const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
-      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("invalid topic name: %s", reason);
-      return nullptr;
-    }
+
+  if (!qos_profile) {
+    RMW_SET_ERROR_MSG("qos_profile is null");
+    return NULL;
   }
-  RMW_CHECK_ARGUMENT_FOR_NULL(publisher_options, nullptr);
+
+  if (!publisher_options) {
+    RMW_SET_ERROR_MSG("publisher_options is null");
+    return NULL;
+  }
 
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
+  if (!node_info) {
+    RMW_SET_ERROR_MSG("node info handle is null");
+    return NULL;
+  }
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
+  if (!participant) {
+    RMW_SET_ERROR_MSG("participant handle is null");
+    return NULL;
+  }
+
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(type_support->data);
-
+  if (!callbacks) {
+    RMW_SET_ERROR_MSG("callbacks handle is null");
+    return NULL;
+  }
   std::string type_name = _create_type_name(callbacks);
   // Past this point, a failure results in unrolling code in the goto fail block.
   DDS::TypeCode * type_code = nullptr;
@@ -325,7 +334,7 @@ fail:
     rmw_free(listener_buf);
   }
 
-  return nullptr;
+  return NULL;
 }
 
 rmw_ret_t
@@ -364,17 +373,18 @@ rmw_publisher_get_actual_qos(
   rmw_qos_profile_t * qos)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    publisher handle,
-    publisher->implementation_identifier,
-    rti_connext_identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-
   RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
 
   auto info = static_cast<ConnextStaticPublisherInfo *>(publisher->data);
+  if (!info) {
+    RMW_SET_ERROR_MSG("publisher internal data is invalid");
+    return RMW_RET_ERROR;
+  }
   DDS::DataWriter * data_writer = info->topic_writer_;
-
+  if (!data_writer) {
+    RMW_SET_ERROR_MSG("publisher internal data writer is invalid");
+    return RMW_RET_ERROR;
+  }
   DDS::DataWriterQos dds_qos;
   DDS::ReturnCode_t status = data_writer->get_qos(dds_qos);
   if (DDS::RETCODE_OK != status) {
@@ -440,79 +450,88 @@ rmw_return_loaned_message_from_publisher(
 rmw_ret_t
 rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
+  if (!node) {
+    RMW_SET_ERROR_MSG("node handle is null");
+    return RMW_RET_ERROR;
+  }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node handle,
-    node->implementation_identifier,
-    rti_connext_identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    node->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
+
+  if (!publisher) {
+    RMW_SET_ERROR_MSG("publisher handle is null");
+    return RMW_RET_ERROR;
+  }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     publisher handle,
-    publisher->implementation_identifier,
-    rti_connext_identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    publisher->implementation_identifier, rti_connext_identifier,
+    return RMW_RET_ERROR)
 
-  rmw_ret_t ret = RMW_RET_OK;
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
+  if (!node_info) {
+    RMW_SET_ERROR_MSG("node info handle is null");
+    return RMW_RET_ERROR;
+  }
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
+  if (!participant) {
+    RMW_SET_ERROR_MSG("participant handle is null");
+    return RMW_RET_ERROR;
+  }
   // TODO(wjwwood): need to figure out when to unregister types with the participant.
   ConnextStaticPublisherInfo * publisher_info =
     static_cast<ConnextStaticPublisherInfo *>(publisher->data);
-  node_info->publisher_listener->remove_information(
-    publisher_info->dds_publisher_->get_instance_handle(), EntityType::Publisher);
-  node_info->publisher_listener->trigger_graph_guard_condition();
-  DDS::Publisher * dds_publisher = publisher_info->dds_publisher_;
+  if (publisher_info) {
+    node_info->publisher_listener->remove_information(
+      publisher_info->dds_publisher_->get_instance_handle(), EntityType::Publisher);
+    node_info->publisher_listener->trigger_graph_guard_condition();
+    DDS::Publisher * dds_publisher = publisher_info->dds_publisher_;
 
-  if (dds_publisher->delete_datawriter(publisher_info->topic_writer_) != DDS::RETCODE_OK) {
-    RMW_SET_ERROR_MSG("failed to delete datawriter");
-    ret = RMW_RET_ERROR;
-  }
-  if (participant->delete_publisher(dds_publisher) != DDS::RETCODE_OK) {
-    if (!rmw_error_is_set()) {
-      RMW_SET_ERROR_MSG("failed to delete publisher");
-      ret = RMW_RET_ERROR;
-    } else {
-      RMW_SAFE_FWRITE_TO_STDERR("failed to delete publisher\n");
+    if (dds_publisher) {
+      if (publisher_info->topic_writer_) {
+        if (dds_publisher->delete_datawriter(publisher_info->topic_writer_) != DDS::RETCODE_OK) {
+          RMW_SET_ERROR_MSG("failed to delete datawriter");
+          return RMW_RET_ERROR;
+        }
+        publisher_info->topic_writer_ = nullptr;
+      }
+      if (participant->delete_publisher(dds_publisher) != DDS::RETCODE_OK) {
+        RMW_SET_ERROR_MSG("failed to delete publisher");
+        return RMW_RET_ERROR;
+      }
+      publisher_info->dds_publisher_ = nullptr;
+    } else if (publisher_info->topic_writer_) {
+      RMW_SET_ERROR_MSG("cannot delete datawriter because the publisher is null");
+      return RMW_RET_ERROR;
     }
-  }
 
-  if (participant->delete_topic(publisher_info->topic_) != DDS::RETCODE_OK) {
-    if (!rmw_error_is_set()) {
-      RMW_SET_ERROR_MSG("failed to delete topic");
-      ret = RMW_RET_ERROR;
-    } else {
-      RMW_SAFE_FWRITE_TO_STDERR("failed to delete topic\n");
+    if (publisher_info->topic_) {
+      if (participant->delete_topic(publisher_info->topic_) != DDS::RETCODE_OK) {
+        RMW_SET_ERROR_MSG("failed to delete topic");
+        return RMW_RET_ERROR;
+      }
+      publisher_info->topic_ = nullptr;
     }
-  }
 
-  ConnextPublisherListener * pub_listener = publisher_info->listener_;
-  if (!rmw_error_is_set()) {
-    RMW_TRY_DESTRUCTOR(
-      pub_listener->~ConnextPublisherListener(),
-      ConnextPublisherListener, ret = RMW_RET_ERROR);
-  } else {
-    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-      pub_listener->~ConnextPublisherListener(),
-      ConnextPublisherListener);
-    ret = RMW_RET_ERROR;
-  }
-  rmw_free(pub_listener);
+    ConnextPublisherListener * pub_listener = publisher_info->listener_;
+    if (pub_listener) {
+      RMW_TRY_DESTRUCTOR(
+        pub_listener->~ConnextPublisherListener(),
+        ConnextPublisherListener, return RMW_RET_ERROR)
+      rmw_free(pub_listener);
+    }
 
-  if (!rmw_error_is_set()) {
     RMW_TRY_DESTRUCTOR(
       publisher_info->~ConnextStaticPublisherInfo(),
-      ConnextStaticPublisherInfo, ret = RMW_RET_ERROR);
-  } else {
-    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-      publisher_info->~ConnextStaticPublisherInfo(),
-      ConnextStaticPublisherInfo);
-    ret = RMW_RET_ERROR;
+      ConnextStaticPublisherInfo, return RMW_RET_ERROR)
+    rmw_free(publisher_info);
+    publisher->data = nullptr;
   }
-  rmw_free(publisher_info);
-  rmw_free(const_cast<char *>(publisher->topic_name));
+  if (publisher->topic_name) {
+    rmw_free(const_cast<char *>(publisher->topic_name));
+  }
   rmw_publisher_free(publisher);
 
-  return ret;
+  return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_connext_shared_cpp/src/qos.cpp
+++ b/rmw_connext_shared_cpp/src/qos.cpp
@@ -49,7 +49,6 @@ set_entity_qos_from_profile_generic(
       break;
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       break;
-    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
     default:
       RMW_SET_ERROR_MSG("Unknown QoS history policy");
       return false;
@@ -64,7 +63,6 @@ set_entity_qos_from_profile_generic(
       break;
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       break;
-    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
     default:
       RMW_SET_ERROR_MSG("Unknown QoS reliability policy");
       return false;
@@ -79,7 +77,6 @@ set_entity_qos_from_profile_generic(
       break;
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       break;
-    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
     default:
       RMW_SET_ERROR_MSG("Unknown QoS durability policy");
       return false;
@@ -104,7 +101,6 @@ set_entity_qos_from_profile_generic(
       break;
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
       break;
-    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
     default:
       RMW_SET_ERROR_MSG("Unknown QoS liveliness policy");
       return false;


### PR DESCRIPTION
This reverts commit ca4ea4c575b7d2c123fa74f6cfa3bf8735bee35c.

Resolves test failures introduced in `rcl`.

Before: https://ci.ros2.org/view/nightly/job/nightly_linux_release/1623/testReport/
After: https://ci.ros2.org/job/ci_linux/11705/testReport
