### PR TITLE
Update graph API return codes.

### DIFF
--- a/rmw_connext_shared_cpp/src/count.cpp
+++ b/rmw_connext_shared_cpp/src/count.cpp
@@ -19,6 +19,8 @@
 #include "rmw_connext_shared_cpp/types.hpp"
 
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
+#include "rmw/validate_full_topic_name.h"
 
 rmw_ret_t
 count_publishers(
@@ -27,32 +29,26 @@ count_publishers(
   const char * topic_name,
   size_t * count)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    implementation_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
   }
-  if (node->implementation_identifier != implementation_identifier) {
-    RMW_SET_ERROR_MSG("node handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
   }
-  if (!topic_name) {
-    RMW_SET_ERROR_MSG("topic name is null");
-    return RMW_RET_ERROR;
-  }
-  if (!count) {
-    RMW_SET_ERROR_MSG("count handle is null");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->publisher_listener) {
-    RMW_SET_ERROR_MSG("publisher listener handle is null");
-    return RMW_RET_ERROR;
-  }
 
   *count = node_info->publisher_listener->count_topic(topic_name);
 
@@ -66,32 +62,26 @@ count_subscribers(
   const char * topic_name,
   size_t * count)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    implementation_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
   }
-  if (node->implementation_identifier != implementation_identifier) {
-    RMW_SET_ERROR_MSG("node handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
   }
-  if (!topic_name) {
-    RMW_SET_ERROR_MSG("topic name is null");
-    return RMW_RET_ERROR;
-  }
-  if (!count) {
-    RMW_SET_ERROR_MSG("count handle is null");
-    return RMW_RET_ERROR;
-  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->subscriber_listener) {
-    RMW_SET_ERROR_MSG("subscriber listener handle is null");
-    return RMW_RET_ERROR;
-  }
 
   *count = node_info->subscriber_listener->count_topic(topic_name);
 

--- a/rmw_connext_shared_cpp/src/node_names.cpp
+++ b/rmw_connext_shared_cpp/src/node_names.cpp
@@ -21,6 +21,7 @@
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
 #include "rmw/impl/cpp/key_value.hpp"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/sanity_checks.h"
 
 #include "rmw_connext_shared_cpp/ndds_include.hpp"
@@ -35,19 +36,17 @@ get_node_names_impl(
   rcutils_string_array_t * node_namespaces,
   rcutils_string_array_t * enclaves)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    implementation_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  if (RMW_RET_OK != rmw_check_zero_rmw_string_array(node_names)) {
+    return RMW_RET_INVALID_ARGUMENT;
   }
-  if (node->implementation_identifier != implementation_identifier) {
-    RMW_SET_ERROR_MSG("node handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
-  if (rmw_check_zero_rmw_string_array(node_names) != RMW_RET_OK) {
-    return RMW_RET_ERROR;
-  }
-  if (rmw_check_zero_rmw_string_array(node_namespaces) != RMW_RET_OK) {
-    return RMW_RET_ERROR;
+  if (RMW_RET_OK != rmw_check_zero_rmw_string_array(node_namespaces)) {
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   DDS::DomainParticipant * participant = static_cast<ConnextNodeInfo *>(node->data)->participant;
@@ -325,8 +324,8 @@ get_node_names_with_enclaves(
   rcutils_string_array_t * node_namespaces,
   rcutils_string_array_t * enclaves)
 {
-  if (rmw_check_zero_rmw_string_array(enclaves) != RMW_RET_OK) {
-    return RMW_RET_ERROR;
+  if (RMW_RET_OK != rmw_check_zero_rmw_string_array(enclaves)) {
+    return RMW_RET_INVALID_ARGUMENT;
   }
   return get_node_names_impl(
     implementation_identifier, node, node_names, node_namespaces, enclaves);

--- a/rmw_connext_shared_cpp/src/service_names_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/service_names_and_types.cpp
@@ -23,6 +23,7 @@
 
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 
 #include "rmw_connext_shared_cpp/demangle.hpp"
 #include "rmw_connext_shared_cpp/names_and_types_helpers.hpp"
@@ -37,36 +38,19 @@ get_service_names_and_types(
   rcutils_allocator_t * allocator,
   rmw_names_and_types_t * service_names_and_types)
 {
-  if (!allocator) {
-    RMW_SET_ERROR_MSG("allocator is null");
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    implementation_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "allocator argument is invalid", return RMW_RET_INVALID_ARGUMENT);
+  if (RMW_RET_OK != rmw_names_and_types_check_zero(service_names_and_types)) {
     return RMW_RET_INVALID_ARGUMENT;
-  }
-  if (!node) {
-    RMW_SET_ERROR_MSG("null node handle");
-    return RMW_RET_INVALID_ARGUMENT;
-  }
-  if (node->implementation_identifier != implementation_identifier) {
-    RMW_SET_ERROR_MSG("node handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
-  rmw_ret_t ret = rmw_names_and_types_check_zero(service_names_and_types);
-  if (ret != RMW_RET_OK) {
-    return ret;
   }
 
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->publisher_listener) {
-    RMW_SET_ERROR_MSG("publisher listener handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->subscriber_listener) {
-    RMW_SET_ERROR_MSG("subscriber listener handle is null");
-    return RMW_RET_ERROR;
-  }
 
   // combine publisher and subscriber information
   std::map<std::string, std::set<std::string>> services;

--- a/rmw_connext_shared_cpp/src/topic_names_and_types.cpp
+++ b/rmw_connext_shared_cpp/src/topic_names_and_types.cpp
@@ -21,6 +21,7 @@
 
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 
 #include "rmw_connext_shared_cpp/demangle.hpp"
 #include "rmw_connext_shared_cpp/namespace_prefix.hpp"
@@ -37,32 +38,19 @@ get_topic_names_and_types(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (node->implementation_identifier != implementation_identifier) {
-    RMW_SET_ERROR_MSG("node handle is not from this rmw implementation");
-    return RMW_RET_ERROR;
-  }
-  rmw_ret_t rmw_ret = rmw_names_and_types_check_zero(topic_names_and_types);
-  if (rmw_ret != RMW_RET_OK) {
-    return rmw_ret;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    implementation_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "allocator argument is invalid", return RMW_RET_INVALID_ARGUMENT);
+  if (RMW_RET_OK != rmw_names_and_types_check_zero(topic_names_and_types)) {
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   auto node_info = static_cast<ConnextNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->publisher_listener) {
-    RMW_SET_ERROR_MSG("publisher listener handle is null");
-    return RMW_RET_ERROR;
-  }
-  if (!node_info->subscriber_listener) {
-    RMW_SET_ERROR_MSG("subscriber listener handle is null");
-    return RMW_RET_ERROR;
-  }
 
   // combine publisher and subscriber information
   std::map<std::string, std::set<std::string>> topics;


### PR DESCRIPTION
Connected to https://github.com/ros2/rmw/pull/272. This patch affects:
- `rmw_get_node_names()`
- `rmw_get_node_names_with_enclaves()`
- `rmw_get_topic_names_and_types()`
- `rmw_get_service_names_and_types()`
- `rmw_get_publishers_info_by_topic()`
- `rmw_get_subscriptions_info_by_topic()`
- `rmw_get_subscriber_names_and_types_by_node()`
- `rmw_get_publisher_names_and_types_by_node()`
- `rmw_get_service_names_and_types_by_node()`
- `rmw_get_client_names_and_types_by_node()`
- `rmw_count_publishers()`
- `rmw_count_subscribers()`
