### PR TITLE
Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size

### DIFF
--- a/rmw_connext_cpp/src/rmw_serialize.cpp
+++ b/rmw_connext_cpp/src/rmw_serialize.cpp
@@ -76,6 +76,6 @@ rmw_get_serialized_message_size(
   size_t * /*size*/)
 {
   RMW_SET_ERROR_MSG("unimplemented");
-  return RMW_RET_ERROR;
+  return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"


### PR DESCRIPTION
Return the right error code. Related with https://github.com/ros2/rmw/pull/281

Signed-off-by: ahcorde <ahcorde@gmail.com>