### PR TITLE
Reduce the shutdown_cleanup_period.

### DIFF
--- a/rmw_connext_shared_cpp/src/node.cpp
+++ b/rmw_connext_shared_cpp/src/node.cpp
@@ -305,6 +305,12 @@ create_node(
     }
   }
 
+  // In order to reduce the time to cleanup a participant (Node), we use the advice from
+  // https://community.rti.com/static/documentation/connext-dds/5.3.1/doc/api/connext_dds/api_cpp/structDDS__DomainParticipantQos.html
+  // and reduce the shutdown_cleanup_period to 50 milliseconds.
+  participant_qos.database.shutdown_cleanup_period.sec = 0;
+  participant_qos.database.shutdown_cleanup_period.nanosec = 50000000;
+
   {
     participant = dpf_->create_participant(
       static_cast<DDS::DomainId_t>(context->actual_domain_id),


### PR DESCRIPTION
This should greatly reduce how long it takes to shutdown a
Connext Node.  In local testing the time went from 3 seconds
to well under a second.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #325; an open question is whether this has any other side-effects.  I'm going to run a full CI with this change in place, and Connext as the only RMW vendor, to see what happens.