### PR TITLE
Use new time_utils function to limit rmw_time_t values to 32-bits

### DIFF
--- a/rmw_connext_shared_cpp/CMakeLists.txt
+++ b/rmw_connext_shared_cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
+find_package(rmw_dds_common REQUIRED)
 
 include_directories(include)
 
@@ -63,6 +64,7 @@ ament_target_dependencies(rmw_connext_shared_cpp
   "rcpputils"
   "rcutils"
   "rmw"
+  "rmw_dds_common"
   "Connext")
 ament_export_libraries(rmw_connext_shared_cpp)
 

--- a/rmw_connext_shared_cpp/package.xml
+++ b/rmw_connext_shared_cpp/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
+  <build_depend>rmw_dds_common</build_depend>
   <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <build_export_depend>connext_cmake_module</build_export_depend>

--- a/rmw_connext_shared_cpp/src/qos.cpp
+++ b/rmw_connext_shared_cpp/src/qos.cpp
@@ -19,6 +19,7 @@
 
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
+#include "rmw_dds_common/time_utils.hpp"
 
 #include "./qos_impl.hpp"
 
@@ -34,9 +35,10 @@ is_time_default(const rmw_time_t & time)
 DDS_Duration_t
 rmw_time_to_dds(const rmw_time_t & time)
 {
+  rmw_time_t clamped_time = rmw_dds_common::clamp_rmw_time_to_dds_time(time);
   DDS_Duration_t duration;
-  duration.sec = static_cast<DDS_Long>(time.sec);
-  duration.nanosec = static_cast<DDS_UnsignedLong>(time.nsec);
+  duration.sec = static_cast<DDS_Long>(clamped_time.sec);
+  duration.nanosec = static_cast<DDS_UnsignedLong>(clamped_time.nsec);
   return duration;
 }
 


### PR DESCRIPTION
Full description here:
https://github.com/ros2/rmw_dds_common/commit/86384ff9b78c587a3097b09680bb35e28646f7aa

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>