### PR TITLE
Handle typesupport errors on retrieval.

### DIFF
--- a/rmw_connext_cpp/src/type_support_common.hpp
+++ b/rmw_connext_cpp/src/type_support_common.hpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <sstream>
 
+#include "rcutils/error_handling.h"
+
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
 
@@ -37,20 +39,29 @@
     get_message_typesupport_handle( \
     TYPE_SUPPORTS, rosidl_typesupport_connext_c__identifier); \
   if (!TYPE_SUPPORT) { \
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string(); \
+    rcutils_reset_error(); \
     TYPE_SUPPORT = get_message_typesupport_handle( \
       TYPE_SUPPORTS, rosidl_typesupport_connext_cpp::typesupport_identifier); \
     if (!TYPE_SUPPORT) { \
+      rcutils_error_string_t error_string = rcutils_get_error_string(); \
+      rcutils_reset_error(); \
       char __msg[1024]; \
       snprintf( \
         __msg, 1024, \
-        "type support handle implementation '%s' (%p) does not match valid type supports " \
-        "('%s' (%p), '%s' (%p))", \
+        "Type support handle implementation '%s' (%p) does not match valid type supports " \
+        "('%s' (%p), '%s' (%p)). Got:\n" \
+        "    %s\n" \
+        "    %s\n" \
+        "while fetching", \
         TYPE_SUPPORTS->typesupport_identifier, \
         static_cast<const void *>(TYPE_SUPPORTS->typesupport_identifier), \
         rosidl_typesupport_connext_cpp::typesupport_identifier, \
         static_cast<const void *>(rosidl_typesupport_connext_cpp::typesupport_identifier), \
         rosidl_typesupport_connext_c__identifier, \
-        static_cast<const void *>(rosidl_typesupport_connext_c__identifier)); \
+        static_cast<const void *>(rosidl_typesupport_connext_c__identifier), \
+        prev_error_string.str, \
+        error_string.str); \
       RMW_SET_ERROR_MSG(__msg); \
       return RET_VAL; \
     } \
@@ -65,20 +76,29 @@
     get_service_typesupport_handle( \
     TYPE_SUPPORTS, rosidl_typesupport_connext_c__identifier); \
   if (!TYPE_SUPPORT) { \
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string(); \
+    rcutils_reset_error(); \
     TYPE_SUPPORT = get_service_typesupport_handle( \
       TYPE_SUPPORTS, rosidl_typesupport_connext_cpp::typesupport_identifier); \
     if (!TYPE_SUPPORT) { \
+      rcutils_error_string_t error_string = rcutils_get_error_string(); \
+      rcutils_reset_error(); \
       char __msg[1024]; \
       snprintf( \
         __msg, 1024, \
         "type support handle implementation '%s' (%p) does not match valid type supports " \
-        "('%s' (%p), '%s' (%p))", \
+        "('%s' (%p), '%s' (%p)). Got:\n" \
+        "    %s\n" \
+        "    %s\n" \
+        "while fetching", \
         TYPE_SUPPORTS->typesupport_identifier, \
         static_cast<const void *>(TYPE_SUPPORTS->typesupport_identifier), \
         rosidl_typesupport_connext_cpp::typesupport_identifier, \
         static_cast<const void *>(rosidl_typesupport_connext_cpp::typesupport_identifier), \
         rosidl_typesupport_connext_c__identifier, \
-        static_cast<const void *>(rosidl_typesupport_connext_c__identifier)); \
+        static_cast<const void *>(rosidl_typesupport_connext_c__identifier), \
+        prev_error_string.str, \
+        error_string.str); \
       RMW_SET_ERROR_MSG(__msg); \
       return RET_VAL; \
     } \


### PR DESCRIPTION
Follow-up after https://github.com/ros2/rosidl_typesupport/pull/99. Missing error handling code caused test failures in downstream packages (e.g. https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/1415/). This patch addresses them.


Full CI (just in case):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13273)](http://ci.ros2.org/job/ci_linux/13273/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8205)](http://ci.ros2.org/job/ci_linux-aarch64/8205/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10993)](http://ci.ros2.org/job/ci_osx/10993/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13304)](http://ci.ros2.org/job/ci_windows/13304/)
