### PR TITLE
Use RMW_DURATION_INFINITE constant

### DIFF
--- a/rmw_connext_cpp/src/rmw_wait.cpp
+++ b/rmw_connext_cpp/src/rmw_wait.cpp
@@ -31,7 +31,7 @@ rmw_wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout)
+  rmw_duration_t wait_timeout)
 {
   return wait<ConnextStaticSubscriberInfo, ConnextStaticServiceInfo, ConnextStaticClientInfo>(
     rti_connext_identifier, subscriptions, guard_conditions, services, clients, events, wait_set,

--- a/rmw_connext_dynamic_cpp/src/functions.cpp
+++ b/rmw_connext_dynamic_cpp/src/functions.cpp
@@ -1673,7 +1673,7 @@ rmw_wait(
   rmw_services_t * services,
   rmw_clients_t * clients,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout)
+  rmw_duration_t wait_timeout)
 {
   return wait<CustomSubscriberInfo, ConnextDynamicServiceInfo, ConnextDynamicClientInfo>
            (rti_connext_dynamic_identifier, subscriptions, guard_conditions, services, clients,

--- a/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
+++ b/rmw_connext_shared_cpp/include/rmw_connext_shared_cpp/wait.hpp
@@ -127,7 +127,7 @@ wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout)
+  rmw_duration_t wait_timeout)
 {
   // To ensure that we properly clean up the wait set, we declare an
   // object whose destructor will detach what we attached (this was previously
@@ -322,12 +322,12 @@ wait(
 
   // invoke wait until one of the conditions triggers
   DDS::Duration_t timeout;
-  if (!wait_timeout) {
+  if (wait_timeout < 0) {
     timeout.sec = DDS::DURATION_INFINITE_SEC;
     timeout.nanosec = DDS::DURATION_INFINITE_NSEC;
   } else {
-    timeout.sec = static_cast<DDS::Long>(wait_timeout->sec);
-    timeout.nanosec = static_cast<DDS::Long>(wait_timeout->nsec);
+    timeout.sec = static_cast<DDS::Long>(wait_timeout / 1000000000LL);
+    timeout.nanosec = static_cast<DDS::Long>(wait_timeout % 1000000000ll);
   }
 
   DDS::ReturnCode_t status = dds_wait_set->wait(*active_conditions, timeout);

--- a/rmw_connext_shared_cpp/src/qos.cpp
+++ b/rmw_connext_shared_cpp/src/qos.cpp
@@ -28,7 +28,9 @@ namespace
 bool
 is_duration_default(rmw_duration_t duration)
 {
-  return duration == RMW_DURATION_INFINITE;
+  // Though the default QoS profiles use RMW_DURATION_INFINITE, historical usage allowed
+  // 0 to mean unspecified, and should not be broken.
+  return duration == 0 || duration == RMW_DURATION_INFINITE;
 }
 
 DDS_Duration_t
@@ -49,8 +51,8 @@ rmw_duration_t
 dds_duration_to_rmw(const DDS_Duration_t & duration)
 {
   if (
-    duration.sec == DDS::DURATION_INFINITE_SEC && duration.nanosec == DDS::DURATION_INFINITE_NSEC
-  ) {
+    duration.sec == DDS::DURATION_INFINITE_SEC && duration.nanosec == DDS::DURATION_INFINITE_NSEC)
+  {
     return RMW_DURATION_INFINITE;
   } else {
     return RCUTILS_S_TO_NS(duration.sec) + duration.nanosec;

--- a/rmw_connext_shared_cpp/test/test_topic_cache.cpp
+++ b/rmw_connext_shared_cpp/test/test_topic_cache.cpp
@@ -34,22 +34,13 @@ bool operator!=(const rmw_qos_profile_t & lhs, const rmw_qos_profile_t & rhs)
   if (lhs.liveliness != rhs.liveliness) {
     return true;
   }
-  if (lhs.liveliness_lease_duration.sec != rhs.liveliness_lease_duration.sec) {
+  if (lhs.liveliness_lease_duration != rhs.liveliness_lease_duration) {
     return true;
   }
-  if (lhs.liveliness_lease_duration.nsec != rhs.liveliness_lease_duration.nsec) {
+  if (lhs.deadline != rhs.deadline) {
     return true;
   }
-  if (lhs.deadline.sec != rhs.deadline.sec) {
-    return true;
-  }
-  if (lhs.deadline.nsec != rhs.deadline.nsec) {
-    return true;
-  }
-  if (lhs.lifespan.sec != rhs.lifespan.sec) {
-    return true;
-  }
-  if (lhs.lifespan.nsec != rhs.lifespan.nsec) {
+  if (lhs.lifespan != rhs.lifespan) {
     return true;
   }
 
@@ -112,23 +103,17 @@ public:
     rmw_qos[0].durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
     rmw_qos[0].reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos[0].liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-    rmw_qos[0].liveliness_lease_duration.sec = 80u;
-    rmw_qos[0].liveliness_lease_duration.nsec = 5555555u;
-    rmw_qos[0].deadline.sec = 123u;
-    rmw_qos[0].deadline.nsec = 5678u;
-    rmw_qos[0].lifespan.sec = 190u;
-    rmw_qos[0].lifespan.nsec = 1234u;
+    rmw_qos[0].liveliness_lease_duration = RCUTILS_S_TO_NS(80u) + 5555555u;
+    rmw_qos[0].deadline = RCUTILS_S_TO_NS(123u) + 5678u;
+    rmw_qos[0].lifespan = RCUTILS_S_TO_NS(190u) + 1234u;
 
     // rmw qos
     rmw_qos[1].durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
     rmw_qos[1].reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_qos[1].liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-    rmw_qos[1].liveliness_lease_duration.sec = 8u;
-    rmw_qos[1].liveliness_lease_duration.nsec = 78901234u;
-    rmw_qos[1].deadline.sec = 12u;
-    rmw_qos[1].deadline.nsec = 1234u;
-    rmw_qos[1].lifespan.sec = 19u;
-    rmw_qos[1].lifespan.nsec = 5432u;
+    rmw_qos[1].liveliness_lease_duration = RCUTILS_S_TO_NS(8u) + 78901234u;
+    rmw_qos[1].deadline = RCUTILS_S_TO_NS(12u) + 1234u;
+    rmw_qos[1].lifespan = RCUTILS_S_TO_NS(19u) + 5432u;
 
     // Add data to topic_cache
     topic_cache.add_information(


### PR DESCRIPTION
Linked to ros2/rmw#255
Depends on #485

Use the newly defined constant RMW_DURATION_INFINITE as both input from ROS2, and as output when reporting QoS values back to ROS 2.