### PR TITLE
Correction for unique network flows feature merged into master

### DIFF
--- a/rmw_connext_cpp/src/rmw_get_network_flow_endpoints.cpp
+++ b/rmw_connext_cpp/src/rmw_get_network_flow_endpoints.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "rmw/error_handling.h"
-#include "rmw/get_network_flow_endpoint.h"
+#include "rmw/get_network_flow_endpoints.h"
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 

--- a/rmw_connext_cpp/src/rmw_get_network_flow_endpoints.cpp
+++ b/rmw_connext_cpp/src/rmw_get_network_flow_endpoints.cpp
@@ -20,7 +20,7 @@
 extern "C"
 {
 rmw_ret_t
-rmw_publisher_get_network_flow_endpoint(
+rmw_publisher_get_network_flow_endpoints(
   const rmw_publisher_t * publisher,
   rcutils_allocator_t * allocator,
   rmw_network_flow_endpoint_array_t * network_flow_endpoint_array)
@@ -28,12 +28,12 @@ rmw_publisher_get_network_flow_endpoint(
   (void) publisher;
   (void) allocator;
   (void) network_flow_endpoint_array;
-  RMW_SET_ERROR_MSG("rmw_publisher_get_network_flow_endpoint not implemented");
+  RMW_SET_ERROR_MSG("rmw_publisher_get_network_flow_endpoints not implemented");
   return RMW_RET_UNSUPPORTED;
 }
 
 rmw_ret_t
-rmw_subscription_get_network_flow_endpoint(
+rmw_subscription_get_network_flow_endpoints(
   const rmw_subscription_t * subscription,
   rcutils_allocator_t * allocator,
   rmw_network_flow_endpoint_array_t * network_flow_endpoint_array)
@@ -41,7 +41,7 @@ rmw_subscription_get_network_flow_endpoint(
   (void) subscription;
   (void) allocator;
   (void) network_flow_endpoint_array;
-  RMW_SET_ERROR_MSG("rmw_subscription_get_network_flow_endpoint not implemented");
+  RMW_SET_ERROR_MSG("rmw_subscription_get_network_flow_endpoints not implemented");
   return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"


### PR DESCRIPTION
This PR corrects typos in the recently merged unique network flows feature ([link](https://github.com/ros2/rmw_connext/pull/484) to closed PR).